### PR TITLE
Feature/ch58773/send raw text to vgs

### DIFF
--- a/framework/Sources/VGSFramework/Core/VGSCollect.swift
+++ b/framework/Sources/VGSFramework/Core/VGSCollect.swift
@@ -86,7 +86,7 @@ extension VGSCollect {
         let allKeys = elements.compactMap({ $0.fieldName })
         allKeys.forEach { key in
             if let value = elements.filter({ $0.fieldName == key }).first {
-                body[key] = value.text
+                body[key] = value.rawText
             } else {
                 fatalError("Wrong key: \(key)")
             }

--- a/framework/Sources/VGSFramework/UIElements/Text Field/Mask/MaskedTextField+padding.swift
+++ b/framework/Sources/VGSFramework/UIElements/Text Field/Mask/MaskedTextField+padding.swift
@@ -11,7 +11,7 @@ import Foundation
 import UIKit
 #endif
 
-public extension MaskedTextField {    
+extension MaskedTextField {    
     override func textRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: padding)
     }

--- a/framework/Sources/VGSFramework/UIElements/Text Field/Mask/MaskedTextField.swift
+++ b/framework/Sources/VGSFramework/UIElements/Text Field/Mask/MaskedTextField.swift
@@ -10,14 +10,16 @@
 import UIKit
 #endif
 
-open class MaskedTextField: UITextField {
+internal class MaskedTextField: UITextField {
 
-    public let lettersAndDigitsReplacementChar: String = "*"
-    public let anyLetterReplecementChar: String = "@"
-    public let lowerCaseLetterReplecementChar: String = "a"
-    public let upperCaseLetterReplecementChar: String = "A"
-    public let digitsReplecementChar: String = "#"
-    
+    enum MaskedTextReplacementChar: String {
+        case lettersAndDigit = "*"
+        case anyLetter = "@"
+        case lowerCaseLetter = "a"
+        case upperCaseLetter = "A"
+        case digits = "#"
+    }
+
     /**
      Var that holds the format pattern that you wish to apply
      to some text
@@ -38,7 +40,7 @@ open class MaskedTextField: UITextField {
     /**
      Var that have the maximum length, based on the mask set
      */
-    open var maxLength: Int {
+    var maxLength: Int {
         get {
             return formatPattern.count + prefix.count
         }
@@ -49,7 +51,7 @@ open class MaskedTextField: UITextField {
      Overriding the var text from UITextField so if any text
      is applied programmatically by calling formatText
      */
-    override open var text: String? {
+    override var text: String? {
         set {
             super.text = newValue
             self.formatText()
@@ -64,16 +66,21 @@ open class MaskedTextField: UITextField {
         return super.text
     }
     
+    /// returns textfield text without mask
+    internal var secureRawText: String? {
+        return getRawText()
+    }
+    
     // MARK: - Text Padding
     var padding: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     
     // MARK: - Constructor
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setup()
     }
     
-    public override init(frame: CGRect) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
         self.setup()
     }
@@ -128,6 +135,13 @@ open class MaskedTextField: UITextField {
         return charactersArray.joined(separator: "")
     }
     
+    fileprivate func getRawText() -> String? {
+        guard let text = secureText else {
+            return nil
+        }
+        return formatPattern.isEmpty ? secureText : getFilteredString(text)
+    }
+    
     fileprivate func getStringWithoutPrefix(_ string: String) -> String {
         if string.range(of: self.prefix) != nil {
             if string.count > self.prefix.count {
@@ -136,19 +150,17 @@ open class MaskedTextField: UITextField {
             } else if string.count == self.prefix.count {
                 return ""
             }
-            
         }
         return string
     }
     
-    // MARK: - Self Public Methods
     /**
      Func that formats the text based on formatPattern
      
      Override this function if you want to customize the behaviour of 
      the class
      */
-    open func formatText() {
+    func formatText() {
         var currentTextForFormatting = ""
         
         if let text = super.text {
@@ -167,44 +179,46 @@ open class MaskedTextField: UITextField {
                 while true {
                     let formatPatternRange = formatterIndex ..< formatPattern.index(after: formatterIndex)
                     let currentFormatCharacter = String(self.formatPattern[formatPatternRange])
-                    
-                    let currentTextForFormattingPatterRange = currentTextForFormattingIndex ..< currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                    let currentTextForFormattingCharacter = String(currentTextForFormatting[currentTextForFormattingPatterRange])
-                    
-                    switch currentFormatCharacter {
-                    case self.lettersAndDigitsReplacementChar:
-                        finalText += currentTextForFormattingCharacter
-                        currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                        formatterIndex = formatPattern.index(after: formatterIndex)
-                    case self.anyLetterReplecementChar:
-                        let filteredChar = self.getOnlyLettersString(currentTextForFormattingCharacter)
-                        if !filteredChar.isEmpty {
-                            finalText += filteredChar
+                    if let currentFormatCharacterType = MaskedTextReplacementChar(rawValue: currentFormatCharacter) {
+                        
+                        let currentTextForFormattingPatterRange = currentTextForFormattingIndex ..< currentTextForFormatting.index(after: currentTextForFormattingIndex)
+                        let currentTextForFormattingCharacter = String(currentTextForFormatting[currentTextForFormattingPatterRange])
+
+                        switch currentFormatCharacterType {
+                        case .lettersAndDigit:
+                            finalText += currentTextForFormattingCharacter
+                            currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
                             formatterIndex = formatPattern.index(after: formatterIndex)
+                        case .anyLetter:
+                            let filteredChar = self.getOnlyLettersString(currentTextForFormattingCharacter)
+                            if !filteredChar.isEmpty {
+                                finalText += filteredChar
+                                formatterIndex = formatPattern.index(after: formatterIndex)
+                            }
+                            currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
+                        case .lowerCaseLetter:
+                            let filteredChar = self.getLowercaseLettersString(currentTextForFormattingCharacter)
+                            if !filteredChar.isEmpty {
+                                finalText += filteredChar
+                                formatterIndex = formatPattern.index(after: formatterIndex)
+                            }
+                            currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
+                        case .upperCaseLetter:
+                            let filteredChar = self.getUppercaseLettersString(currentTextForFormattingCharacter)
+                            if !filteredChar.isEmpty {
+                                finalText += filteredChar
+                                formatterIndex = formatPattern.index(after: formatterIndex)
+                            }
+                            currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
+                        case .digits:
+                            let filteredChar = self.getOnlyDigitsString(currentTextForFormattingCharacter)
+                            if !filteredChar.isEmpty {
+                                finalText += filteredChar
+                                formatterIndex = formatPattern.index(after: formatterIndex)
+                            }
+                            currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
                         }
-                        currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                    case self.lowerCaseLetterReplecementChar:
-                        let filteredChar = self.getLowercaseLettersString(currentTextForFormattingCharacter)
-                        if !filteredChar.isEmpty {
-                            finalText += filteredChar
-                            formatterIndex = formatPattern.index(after: formatterIndex)
-                        }
-                        currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                    case self.upperCaseLetterReplecementChar:
-                        let filteredChar = self.getUppercaseLettersString(currentTextForFormattingCharacter)
-                        if !filteredChar.isEmpty {
-                            finalText += filteredChar
-                            formatterIndex = formatPattern.index(after: formatterIndex)
-                        }
-                        currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                    case self.digitsReplecementChar:
-                        let filteredChar = self.getOnlyDigitsString(currentTextForFormattingCharacter)
-                        if !filteredChar.isEmpty {
-                            finalText += filteredChar
-                            formatterIndex = formatPattern.index(after: formatterIndex)
-                        }
-                        currentTextForFormattingIndex = currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                    default:
+                    } else {
                         finalText += currentFormatCharacter
                         formatterIndex = formatPattern.index(after: formatterIndex)
                     }

--- a/framework/Sources/VGSFramework/UIElements/Text Field/VGSTextField.swift
+++ b/framework/Sources/VGSFramework/UIElements/Text Field/VGSTextField.swift
@@ -30,18 +30,24 @@ public class VGSTextField: UIView {
             }
         }
     }
+    
     internal var isRequired: Bool = false
     internal var fieldType: FieldType = .none
     internal var validationModel = VGSValidation()
     internal var fieldName: String!
     internal var token: String?
     
-    var updateUI: (() -> Void)?
-    
-    // just for internal using
+    /// Should be only for internal use. Returns textfield text with mask
     internal var text: String? {
         return textField.secureText
     }
+    
+    /// Returns textField text without mask
+    internal var rawText: String? {
+        return textField.secureRawText
+    }
+    
+    internal var updateUI: (() -> Void)?
     
     /// Textfield placeholder string
     public var placeholder: String? {
@@ -79,7 +85,7 @@ public class VGSTextField: UIView {
             textField.isSecureTextEntry = configuration.type.isSecureDate
             textField.keyboardType = configuration.keyboardType ?? configuration.type.keyboardType
             textField.returnKeyType = configuration.returnKeyType ?? .default
-            
+
             if configuration.formatPattern.count != 0 {
                 textField.formatPattern = configuration.formatPattern
             } else {
@@ -158,6 +164,7 @@ public class VGSTextField: UIView {
 
 // MARK: - Textfiled delegate
 extension VGSTextField: UITextFieldDelegate {
+        
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
         guard let tfText = textField.text else {
@@ -168,10 +175,9 @@ extension VGSTextField: UITextFieldDelegate {
         if mask.count < tfText.count + string.count {
             return false
         }
-        
         return true
     }
-
+    
     public func textFieldDidBeginEditing(_ textField: UITextField) {
         delegate?.vgsTextFieldDidBeginEditing?(self)
     }

--- a/framework/Tests/FrameworkTests/Text Fields Tests/MaskedTextFieldTest.swift
+++ b/framework/Tests/FrameworkTests/Text Fields Tests/MaskedTextFieldTest.swift
@@ -1,0 +1,121 @@
+//
+//  MaskedTextFieldTest.swift
+//  FrameworkTests
+//
+//  Created by Dima on 27.01.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+import XCTest
+@testable import VGSFramework
+
+class MaskedTextFieldTest: XCTestCase {
+    var collector: VGSCollect!
+    var configuration: VGSConfiguration!
+    var textfield: VGSTextField!
+    
+    override func setUp() {
+        collector = VGSCollect(id: "vaultid")
+        configuration = VGSConfiguration.init(collector: collector, fieldName: "test1")
+        textfield = VGSTextField()
+        textfield.configuration = configuration
+    }
+    
+    override func tearDown() {
+        collector  = nil
+        configuration = nil
+        textfield = nil
+    }
+    
+    func testDigitsMaskingText() {
+        configuration.formatPattern = "#### ####-####.####"
+        textfield.configuration = configuration
+        textfield.textField.text = "011122223333444455556"
+        XCTAssertTrue(textfield.text == "0111 2222-3333.4444")
+        
+        configuration.formatPattern = "#### ####_####?##+##"
+        textfield.configuration = configuration
+        textfield.textField.text = " adf 01112222 333344445555sd"
+        XCTAssertTrue(textfield.text == "0111 2222_3333?44+44")
+    }
+    
+    func testLettersMaskingText() {
+        configuration.formatPattern = "AAAA aaaa-aAaA.@@@@"
+        textfield.configuration = configuration
+        textfield.textField.text = "TEST test-tEsT.tEsTu"
+        XCTAssertTrue(textfield.text == "TEST test-tEsT.tEsT")
+        
+        configuration.formatPattern = "AAAA aaaa-aAaA.@@@@"
+        textfield.configuration = configuration
+        textfield.textField.text = " 1234TEST test1tEsT1tEsT"
+        XCTAssertTrue(textfield.text == "TEST test-tEsT.tEsT")
+    }
+    
+    func testLettersAndDigitMaskingText() {
+        configuration.formatPattern = ""
+        textfield.configuration = configuration
+        textfield.textField.text = " Aa11_22:22/33+ 2s"
+        XCTAssertTrue(textfield.text == " Aa11_22:22/33+ 2s")
+        
+        configuration.formatPattern = "****"
+        textfield.configuration = configuration
+        textfield.textField.text = "Aa1122223333444455556"
+        XCTAssertTrue(textfield.text == "Aa11")
+
+        configuration.formatPattern = "**./_:+**"
+        textfield.configuration = configuration
+        textfield.textField.text = " tE2 5test"
+        XCTAssertTrue(textfield.text == "tE./_:+25")
+    }
+    
+    func testGetRawDigitsText() {
+        configuration.formatPattern = "#### #### #### ####"
+        textfield.configuration = configuration
+        textfield.textField.text = "4111111111111111"
+        XCTAssertTrue(textfield.rawText == "4111111111111111")
+        
+        configuration.formatPattern = " ####-####?####_####.#### "
+        textfield.configuration = configuration
+        textfield.textField.text = "411122223333444455556"
+        XCTAssertTrue(textfield.rawText == "41112222333344445555")
+        
+        configuration.formatPattern = " _##/## "
+        textfield.configuration = configuration
+        textfield.textField.text = "012345678"
+        XCTAssertTrue(textfield.rawText == "0123")
+        
+        configuration.formatPattern = "####-"
+        textfield.configuration = configuration
+        textfield.textField.text = "4111"
+        XCTAssertTrue(textfield.rawText == "4111")
+    }
+    
+    func testGetRawLettersText() {
+        configuration.formatPattern = "AAAA aaaa-aAaA.@@@@"
+        textfield.configuration = configuration
+        textfield.textField.text = "TESTtesttEsTtEsTu"
+        XCTAssertTrue(textfield.rawText == "TESTtesttEsTtEsT")
+        
+        configuration.formatPattern = "AAAA aaaa-aAaA.@@@@"
+        textfield.configuration = configuration
+        textfield.textField.text = " 1234TEST test1tEsT1tEsT"
+        XCTAssertTrue(textfield.rawText == "TESTtesttEsTtEsT")
+    }
+    
+    func testGetRawLettersAndDigitsText() {
+        configuration.formatPattern = ""
+        textfield.configuration = configuration
+        textfield.textField.text = " Aa11_22:22/33+ 2s"
+        XCTAssertTrue(textfield.rawText == " Aa11_22:22/33+ 2s")
+        
+        configuration.formatPattern = "****"
+        textfield.configuration = configuration
+        textfield.textField.text = "Aa1122223333444455556"
+        XCTAssertTrue(textfield.rawText == "Aa11")
+
+        configuration.formatPattern = "**./_:+**"
+        textfield.configuration = configuration
+        textfield.textField.text = " tE2 5test"
+        XCTAssertTrue(textfield.rawText == "tE25")
+    }
+}

--- a/framework/VGSFramework.xcodeproj/project.pbxproj
+++ b/framework/VGSFramework.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3222A47B23CC6A4D00836A8D /* VGSCollectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3222A47A23CC6A4D00836A8D /* VGSCollectTests.swift */; };
 		328B5C7023C8DA2600A39515 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328B5C6F23C8DA2600A39515 /* String+extension.swift */; };
 		328B5C7123C8DA2600A39515 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328B5C6F23C8DA2600A39515 /* String+extension.swift */; };
+		3299585D23DF043D0018FA50 /* MaskedTextFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3299585C23DF043D0018FA50 /* MaskedTextFieldTest.swift */; };
 		3C514B5FF66E3CC4BE524AC2 /* Pods_VGSFramework_FrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A740A88CAAE48B864A452F49 /* Pods_VGSFramework_FrameworkTests.framework */; };
 		D06AC61B18447F6EC1968FDE /* Pods_VGSFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F581972075FB28A79E9D585 /* Pods_VGSFramework.framework */; };
 		FD05F9472316CE5A000EAF52 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD05F9392316CE5A000EAF52 /* Storage.swift */; };
@@ -64,6 +65,7 @@
 		320E885223A94E1800A9C1FA /* CharacterSet+extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CharacterSet+extension.swift"; sourceTree = "<group>"; };
 		3222A47A23CC6A4D00836A8D /* VGSCollectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCollectTests.swift; sourceTree = "<group>"; };
 		328B5C6F23C8DA2600A39515 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
+		3299585C23DF043D0018FA50 /* MaskedTextFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskedTextFieldTest.swift; sourceTree = "<group>"; };
 		3A48B7ABDDE4E25468A3F77B /* Pods_VGSFrameworkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_VGSFrameworkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D4BC633274FE748E7FD0F90 /* Pods-VGSFramework-FrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VGSFramework-FrameworkTests.release.xcconfig"; path = "Target Support Files/Pods-VGSFramework-FrameworkTests/Pods-VGSFramework-FrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
 		6E922F61637505248BC10DE4 /* Pods-VGSFrameworkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VGSFrameworkTests.debug.xcconfig"; path = "Target Support Files/Pods-VGSFrameworkTests/Pods-VGSFrameworkTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				FDE8907C2333A1D400FA170D /* CVVTextFieldTests.swift */,
 				FDE8907A2333A16A00FA170D /* ExpDateTextFieldTests.swift */,
 				FDF696E2234643F300063507 /* LuhnTests.swift */,
+				3299585C23DF043D0018FA50 /* MaskedTextFieldTest.swift */,
 				FD4ED0E42373666500AEAD24 /* TextFieldSecurity.swift */,
 				FDF696E023463ACA00063507 /* TextFielsStyleUI.swift */,
 				FDA680DE239844FC00372817 /* CardTextFieldTests.swift */,
@@ -556,6 +559,7 @@
 				3222A47B23CC6A4D00836A8D /* VGSCollectTests.swift in Sources */,
 				FD4ED0E52373666500AEAD24 /* TextFieldSecurity.swift in Sources */,
 				FD24955E2330CC62009024E6 /* CollectorTests.swift in Sources */,
+				3299585D23DF043D0018FA50 /* MaskedTextFieldTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Fixes [58773](https://app.clubhouse.io/vgs/story/58773/vgs-collect-ios-send-to-backend-textfield-text-without-mask) 
Send to vgs backend textfield text without mask.

## Description of changes in release / Impact of release:
VGSTextfield text will be send without mask to vgs backend.

## Screenshots / gif (if customer facing):
(insert image here)

## Value being added to the product or risk being removed by this release
(insert text here)

## Changes to documentation (put link to pull request if some EXISTING docs page needs changes) 
- [ ] My change requires a change to the documentation.
(insert link here)
- [ ] I have updated the documentation accordingly.
(insert link here)

## Backout procedure

Deploy the previous release.
