### PR TITLE
Optional scan modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 Podfile.lock
 demoapp/Podfile.lock
 Carthage
+Cartfile.resolved

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "getbouncer/cardscan-ios" "master"
-github "verygoodsecurity/card.io-iOS-source"
+github "getbouncer/cardscan-ios" "1.0.5048"
+github "verygoodsecurity/card.io-iOS-source" "b43a202acd7c7a258930b675348f8c4086f32e5d"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
+github "getbouncer/cardscan-ios" "master"
 github "verygoodsecurity/card.io-iOS-source"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,22 @@ then run:
 carthage update --platform iOS
 ```
 
-Note that `VGSCollectSDK` includes [CardIO](https://github.com/verygoodsecurity/card.io-iOS-source) as dependency for scanning card numbers. You should also link it to your project. Follow the [Carthage instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)
+If you don't need additional features like card scanning, you should add into your project only `VGSCollectSDK`. Other submodules can safely be deleted from Carthage Build folder.
 
+
+Check VGSCollecSDK submodules and required frameworks:
+
+| Build Frameworks | Core SDK  | CardIO | Card Scan   |
+| ----- | -------------- |---------------- |--------------- |
+| VGSCollectSDK   | ✔ | ✔ | ✔|
+| CardIO  |  | ✔ |  |
+| VGSCardIOCollector |  |✔ |  |
+| CardScan  |  |  |   ✔ |
+| VGSCardScanCollector |  |  | ✔ |
+
+Don't forget to import `VGSCardIOCollector` or `VGSCardScanCollector` in files where you use scan modules.
+
+> NOTE: At this time **Carthage** does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built by default. However you can include into your project only submodules that you need.
 
 ## Usage
 
@@ -198,12 +212,33 @@ Use your `<vaultId>` to initialize VGSCollect instance. You can get it in your [
 
 
 ### Scan Credit Card Data
-VGSCollect provide secure [card.io](https://github.com/verygoodsecurity/CardIOSDK-iOS) integration for collecting and setting scanned data into ``VGSTextFields``. 
-To use [card.io](https://github.com/verygoodsecurity/CardIOSDK-iOS) with **VGSCollectSDK** you should add **CardIO** module alongside with core **VGSCollectSDK** module into your App Podfile:
+VGS Collect SDK provides several card scan solutions for the Payment Card Industry to help protect your businesses and the sensitive information of your consumers. It's required to use only Scan modules provided by VGS, which are audited by VGS PCI requirements.
+
+#### Integrate with Cocoapods
+
+Add 'VGSCollectSDK' alongside with one of scan modules pod:
+
 ```ruby
 pod 'VGSCollectSDK'
-pod 'VGSCollectSDK/CardIO'
+
+# Add CardIO module to use Card.io as scan provider
+pod 'VGSCollectSDK/CardIO' 
+
+# Add CardScan module to use CardScan(Bouncer) as scan provider
+pod 'VGSCollectSDK/CardScan' 
 ```
+
+#### Integrate with Carthage
+
+Carthage users should point to `VGSCollectSDK` repository and use next generated framework:
+
+-  To use **Card.io**: `VGSCollectSDK`, `VGSCardIOCollector`, and `CardIO`. In your file add `import VGSCardIOCollector`.
+-  To use **Card Scan**: `VGSCollectSDK`, `VGSCardScanCollector`, and `CardScan`. In your file add `import VGSCardScanCollector`.
+
+Other submodules can safely be deleted from Carthage Build folder.
+
+> NOTE: At this time, **Carthage** does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built by default. However you can include into your project only submodules that you need.
+
 
 #### Code Example
 
@@ -425,8 +460,9 @@ To follow `VGSCollectSDK` updates and changes check the [releases](https://githu
 ## Dependencies
 - iOS 10+
 - Swift 5
-- 3rd party libraries:
-  - CardIO(optional)
+- Optional 3rd party libraries:
+  - [CardIO](https://github.com/card-io/card.io-iOS-SDK)
+  - [Card Scan(Bouncer)](https://github.com/getbouncer/cardscan-ios)
 
 ## License
 

--- a/Sources/VGSCardIOCollector/VGSCardIOHandler.swift
+++ b/Sources/VGSCardIOCollector/VGSCardIOHandler.swift
@@ -7,13 +7,14 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+import CardIO
 import UIKit
+import AVFoundation.AVCaptureDevice
+
+#if !COCOAPODS
+import VGSCollectSDK
 #endif
 
-#if canImport(CardIO)
-import CardIO
-import AVFoundation.AVCaptureDevice
 
 internal class VGSCardIOHandler: NSObject, VGSScanHandlerProtocol {
     
@@ -48,13 +49,13 @@ extension VGSCardIOHandler: CardIOPaymentViewControllerDelegate {
     
     /// :nodoc:
     func userDidCancel(_ paymentViewController: CardIOPaymentViewController!) {
-        delegate?.userDidCancelScan?()
+        delegate?.userDidCancelScan()
     }
     
     /// :nodoc:
     func userDidProvide(_ cardInfo: CardIOCreditCardInfo!, in paymentViewController: CardIOPaymentViewController!) {
         guard let cardInfo = cardInfo, let cardIOdelegate = delegate else {
-            delegate?.userDidFinishScan?()
+            delegate?.userDidFinishScan()
             return
         }
         if !cardInfo.cardNumber.isEmpty, let textfield = cardIOdelegate.textFieldForScannedData(type: .cardNumber) {
@@ -87,7 +88,7 @@ extension VGSCardIOHandler: CardIOPaymentViewControllerDelegate {
         if let cvc = cardInfo.cvv, !cvc.isEmpty, let textfield = cardIOdelegate.textFieldForScannedData(type: .cvc) {
             textfield.setText(cvc)
         }
-        cardIOdelegate.userDidFinishScan?()
+        cardIOdelegate.userDidFinishScan()
     }
 }
-#endif
+

--- a/Sources/VGSCardIOCollector/VGSCardIOHandler.swift
+++ b/Sources/VGSCardIOCollector/VGSCardIOHandler.swift
@@ -49,6 +49,7 @@ extension VGSCardIOHandler: CardIOPaymentViewControllerDelegate {
     
     /// :nodoc:
     func userDidCancel(_ paymentViewController: CardIOPaymentViewController!) {
+      VGSAnalyticsClient.shared.trackEvent(.scan, status: .cancel, extraData: [ "scannerType": "CardIO"])
         delegate?.userDidCancelScan()
     }
     
@@ -59,6 +60,9 @@ extension VGSCardIOHandler: CardIOPaymentViewControllerDelegate {
             return
         }
         if !cardInfo.cardNumber.isEmpty, let textfield = cardIOdelegate.textFieldForScannedData(type: .cardNumber) {
+            if let form = textfield.vgsCollector {
+              VGSAnalyticsClient.shared.trackFormEvent(form, type: .scan, status: .success, extraData: [ "scannerType": "CardIO"])
+            }
             textfield.setText(cardInfo.cardNumber)
         }
         if  1...12 ~= Int(cardInfo.expiryMonth), cardInfo.expiryYear >= 2020 {

--- a/Sources/VGSCardIOCollector/VGSCardIOScanController.swift
+++ b/Sources/VGSCardIOCollector/VGSCardIOScanController.swift
@@ -7,29 +7,21 @@
 //
 
 import Foundation
-import AVFoundation.AVCaptureDevice
 
-#if canImport(UIKit)
-import UIKit
+#if !COCOAPODS
+import VGSCollectSDK
 #endif
 
-internal protocol VGSScanHandlerProtocol {
-    var delegate: VGSCardIOScanControllerDelegate? { get set }
-    var cameraPosition: AVCaptureDevice.Position? { get set }
-    var languageOrLocale: String? { get set }
-    var disableManualEntryButtons: Bool { get set }
-    var suppressScanConfirmation: Bool { get set }
-    
-    func presentScanVC(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?)
-    func dismissScanVC(animated: Bool, completion: (() -> Void)?)
-}
+#if os(iOS)
+import UIKit
+import AVFoundation.AVCaptureDevice
 
 /// Controller responsible for managing Card.io scanner
 public class VGSCardIOScanController {
     
     // MARK: - Attributes
     
-    internal var scanHandler: VGSScanHandlerProtocol?
+    internal var scanHandler: VGSCardIOHandler?
     
     /// `VGSCardIOScanControllerDelegate` - handle user interaction with `Card.io` scanner
     public var delegate: VGSCardIOScanControllerDelegate? {
@@ -77,13 +69,8 @@ public class VGSCardIOScanController {
     /// - Parameters:
     ///   - delegate: `VGSCardIOScanControllerDelegate`. Default is `nil`.
     public required init(_ delegate: VGSCardIOScanControllerDelegate? = nil) {
-        #if canImport(CardIO)
             self.scanHandler = VGSCardIOHandler()
             self.delegate = delegate
-        #else
-            print("Can't import CardIO. Please check that CardIO submodule is installed")
-            return
-        #endif
     }
     
     // MARK: - Methods
@@ -106,3 +93,4 @@ public class VGSCardIOScanController {
         scanHandler?.dismissScanVC(animated: animated, completion: completion)
     }
 }
+#endif

--- a/Sources/VGSCardIOCollector/VGSCardIOScanControllerDelegate.swift
+++ b/Sources/VGSCardIOCollector/VGSCardIOScanControllerDelegate.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
+import VGSCollectSDK
+#endif
 
 /// Supported scan data fields by Card.io
 @objc
@@ -41,10 +44,10 @@ public protocol VGSCardIOScanControllerDelegate {
     // MARK: - Handle user ineraction with `Card.io`
     
     /// On user confirm scanned data by selecting Done button on `Card.io` screen.
-    @objc optional func userDidFinishScan()
+    @objc func userDidFinishScan()
     
     /// On user press Cancel buttonn on `Card.io` screen.
-    @objc optional func userDidCancelScan()
+    @objc func userDidCancelScan()
     
     // MARK: - Manage scanned data
     

--- a/Sources/VGSCardScanCollector/VGSCardScanController.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanController.swift
@@ -1,0 +1,66 @@
+//
+//  VGSCardScanController.swift
+//  VGSCardScanCollector
+//
+//  Created by Dima on 18.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+import Foundation
+#if !COCOAPODS
+import VGSCollectSDK
+#endif
+
+/// Controller responsible for managing CardScan scanner
+public class VGSCardScanController {
+    
+    // MARK: - Attributes
+    
+    internal var scanHandler: VGSCardScanHandler?
+    
+    /// `VGSCardScanControllerDelegate` - handle user interaction with `CardScan` scanner
+    public var delegate: VGSCardScanControllerDelegate? {
+      set {
+        scanHandler?.delegate = newValue
+      }
+      get {
+        return scanHandler?.delegate
+      }
+    }
+    
+    // MARK: - Initialization
+    /// Initialization
+    ///
+    /// - Parameters:
+    ///   - delegate: `VGSCardScanControllerDelegate`. Default is `nil`.
+    public required init(apiKey: String, delegate: VGSCardScanControllerDelegate? = nil) {
+          
+      self.scanHandler = VGSCardScanHandler(apiKey: apiKey)
+      self.delegate = delegate
+    }
+    
+    // MARK: - Methods
+    
+    /// Present `CardScan` scanner.
+    /// - Parameters:
+    ///   - viewController: `UIViewController` that will present card scanner.
+    ///   - animated: pass `true` to animate the presentation; otherwise, pass `false`.
+    ///   - completion: the block to execute after the presentation finishes.
+    public func presentCardScanner(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        scanHandler?.presentScanVC(on: viewController, animated: animated, completion: completion)
+    }
+    
+    /// Dismiss `CardScan` scanner.
+    ///
+    /// - Parameters:
+    ///   - animated: pass `true` to animate the dismiss of presented viewcontroller; otherwise, pass `false`.
+    ///   - completion: the block to execute after the dismiss finishes.
+    public func dismissCardScanner(animated: Bool, completion: (() -> Void)?) {
+        scanHandler?.dismissScanVC(animated: animated, completion: completion)
+    }
+  
+    /// Check if CardScan can run on current device.
+    static public func isCompatible() -> Bool {
+      return VGSCardScanHandler.isCompatible()
+    }
+}

--- a/Sources/VGSCardScanCollector/VGSCardScanControllerDelegate.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanControllerDelegate.swift
@@ -1,0 +1,57 @@
+//
+//  VGSCardScanControllerDelegate.swift
+//  VGSCardScanCollector
+//
+//  Created by Dima on 31.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+import Foundation
+#if !COCOAPODS
+import VGSCollectSDK
+#endif
+
+/// Supported scan data fields by CardScan
+@objc
+public enum CradScanDataType: Int {
+    
+    /// Credit Card Number. Digits string.
+    case cardNumber
+    
+    /// Credit Card Expiration Date. String in format "01/21".
+    case expirationDate
+    
+    /// Credit Card Expiration Month. String in format "01".
+    case expirationMonth
+    
+    /// Credit Card Expiration Year. String in format "21".
+    case expirationYear
+  
+    /// Credit Card Expiration Date. String in format "01/2021".
+    case expirationDateLong
+  
+    /// Credit Card Expiration Year. String in format "2021".
+    case expirationYearLong
+  
+    /// Card holder name displayed on card.
+    case name
+}
+
+/// Delegates produced by `VGSCardScanController` instance.
+@objc
+public protocol VGSCardScanControllerDelegate {
+    
+    // MARK: - Handle user ineraction with `CardScan`
+    
+    /// On user confirm scanned data by selecting Done button on `CardScan` screen.
+    @objc func userDidFinishScan()
+    
+    /// On user press Cancel buttonn on `CardScan` screen.
+    @objc func userDidCancelScan()
+    
+    // MARK: - Manage scanned data
+    
+    /// Asks `VGSTextField` where scanned data with `VGSConfiguration.FieldType` need to be set. Called after user select Done button, just before userDidFinishScan() delegate.
+    @objc func textFieldForScannedData(type: CradScanDataType) -> VGSTextField?
+}
+

--- a/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
@@ -44,6 +44,7 @@ internal class VGSCardScanHandler: NSObject, VGSScanHandlerProtocol {
 /// :nodoc:
 extension VGSCardScanHandler: ScanDelegate {
   func userDidCancel(_ scanViewController: ScanViewController) {
+    VGSAnalyticsClient.shared.trackEvent(.scan, status: .cancel, extraData: [ "scannerType": "Bouncer"])
     delegate?.userDidCancelScan()
   }
   
@@ -52,9 +53,13 @@ extension VGSCardScanHandler: ScanDelegate {
     guard let cardScanDelegate = delegate else {
       return
     }
-
+    
     if !creditCard.number.isEmpty, let textfield = cardScanDelegate.textFieldForScannedData(type: .cardNumber) {
-       textfield.setText(creditCard.number)
+    
+      if let form = textfield.vgsCollector {
+        VGSAnalyticsClient.shared.trackFormEvent(form, type: .scan, status: .success, extraData: [ "scannerType": "Bouncer"])
+      }
+      textfield.setText(creditCard.number)
     }
     if let name = creditCard.name, !name.isEmpty, let textfield =
       cardScanDelegate.textFieldForScannedData(type: .name) {

--- a/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
@@ -1,0 +1,91 @@
+//
+//  VGSCardScanHandler.swift
+//  VGSCardScanCollector
+//
+//  Created by Dima on 18.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+import Foundation
+import CardScan
+#if !COCOAPODS
+import VGSCollectSDK
+#endif
+
+internal class VGSCardScanHandler: NSObject, VGSScanHandlerProtocol {
+    
+    weak var delegate: VGSCardScanControllerDelegate?
+    weak var view: UIViewController?
+  
+    required init(apiKey: String) {
+      super.init()
+      ScanViewController.configure(apiKey: apiKey)
+    }
+    
+    func presentScanVC(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        guard let vc = ScanViewController.createViewController(withDelegate: self) else {
+            print("This device is incompatible with CardScan")
+            return
+        }
+        self.view = vc
+        vc.scanDelegate = self
+        viewController.present(vc, animated: true)
+    }
+    
+    func dismissScanVC(animated: Bool, completion: (() -> Void)?) {
+        view?.dismiss(animated: animated, completion: completion)
+    }
+  
+    static func isCompatible() -> Bool {
+      return ScanViewController.isCompatible()
+    }
+}
+
+/// :nodoc:
+extension VGSCardScanHandler: ScanDelegate {
+  func userDidCancel(_ scanViewController: ScanViewController) {
+    delegate?.userDidCancelScan()
+  }
+  
+  /// :nodoc:
+  func userDidScanCard(_ scanViewController: ScanViewController, creditCard: CreditCard) {
+    guard let cardScanDelegate = delegate else {
+      return
+    }
+
+    if !creditCard.number.isEmpty, let textfield = cardScanDelegate.textFieldForScannedData(type: .cardNumber) {
+       textfield.setText(creditCard.number)
+    }
+    if let name = creditCard.name, !name.isEmpty, let textfield =
+      cardScanDelegate.textFieldForScannedData(type: .name) {
+      textfield.setText(name)
+    }
+    if let month = Int(creditCard.expiryMonth ?? ""), 1...12 ~= month, let year = Int(creditCard.expiryYear ?? ""), year >= 20 {
+     if let textfield = cardScanDelegate.textFieldForScannedData(type: .expirationDate) {
+       textfield.setText("\(month)\(year)")
+     }
+     if let textfield = cardScanDelegate.textFieldForScannedData(type: .expirationDateLong) {
+       let longYear = "20\(year)"
+       textfield.setText("\(month)\(longYear)")
+     }
+    }
+    if let month = Int(creditCard.expiryMonth ?? ""), 1...12 ~= month, let textfield = cardScanDelegate.textFieldForScannedData(type: .expirationMonth) {
+       textfield.setText("\(month)")
+    }
+    if let year = Int(creditCard.expiryYear ?? ""), year >= 20 {
+     if let textfield = cardScanDelegate.textFieldForScannedData(type: .expirationYear) {
+       textfield.setText("\(year)")
+     }
+     if let textfield = cardScanDelegate.textFieldForScannedData(type: .expirationYearLong) {
+       let longYear = "20\(year)"
+       textfield.setText("\(longYear)")
+     }
+    }
+     cardScanDelegate.userDidFinishScan()
+  }
+  
+  /// :nodoc:
+  func userDidSkip(_ scanViewController: ScanViewController) {
+    delegate?.userDidCancelScan()
+  }
+}

--- a/Sources/VGSCollectSDK/Core/Analytics/VGSAnalyticsClient.swift
+++ b/Sources/VGSCollectSDK/Core/Analytics/VGSAnalyticsClient.swift
@@ -13,6 +13,7 @@ public enum VGSAnalyticsEventType: String {
   case fieldInit = "Init"
   case beforeSubmit = "BeforeSubmit"
   case submit = "Submit"
+  case scan = "Scan"
 }
 
 /// Client responsably for managing and sending VGS Collect SDK analytics events.
@@ -23,6 +24,7 @@ public class VGSAnalyticsClient {
   public enum AnalyticEventStatus: String {
     case success = "Ok"
     case failed = "Failed"
+    case cancel = "Cancel"
   }
   
   /// Shared `VGSAnalyticsClient` instance

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect+extension.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect+extension.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/Core/Enums.swift
+++ b/Sources/VGSCollectSDK/Core/Enums.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Vitalii Obertynskyi. All rights reserved.
 //
 
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/Core/Storage.swift
+++ b/Sources/VGSCollectSDK/Core/Storage.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/Core/VGSConfiguration.swift
+++ b/Sources/VGSCollectSDK/Core/VGSConfiguration.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/Integrations/CardScanners/CrardScannerInteractionProtocol.swift
+++ b/Sources/VGSCollectSDK/Integrations/CardScanners/CrardScannerInteractionProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  CrardScannerInteractionProtocol.swift
+//  VGSCollectSDK
+//
+//  Created by Dima on 28.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+import Foundation
+public protocol VGSScanHandlerProtocol {
+//    var delegate: VGSCardScanControllerDelegate? { get set }
+//    var cameraPosition: AVCaptureDevice.Position? { get set }
+    
+    func presentScanVC(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?)
+    func dismissScanVC(animated: Bool, completion: (() -> Void)?)
+}

--- a/Sources/VGSCollectSDK/UIElements/FilePicker/VGSFilePickerControllerDelegate.swift
+++ b/Sources/VGSCollectSDK/UIElements/FilePicker/VGSFilePickerControllerDelegate.swift
@@ -12,7 +12,7 @@ import Foundation
 @objc
 public protocol VGSFilePickerControllerDelegate {
     
-    // MARK: - Handle user ineraction with `Card.io`.
+    // MARK: - Handle user ineraction.
     
     /// On user select a file
     ///

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField+security.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField+security.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Vitalii Obertynskyi. All rights reserved.
 //
 
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/State/State.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/State/State.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSCardTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSCardTextField.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Vitalii Obertynskyi. All rights reserved.
 //
 
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField+UIBuilder.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField+UIBuilder.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField+state.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField+state.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Vitalii Obertynskyi. All rights reserved.
 //
 
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextFieldDelegate.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextFieldDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Validation/Card/CardType+icon.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Validation/Card/CardType+icon.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if os(iOS)
 import UIKit
 #endif
 

--- a/VGSCardIOCollector/Info.plist
+++ b/VGSCardIOCollector/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/VGSCardIOCollector/VGSCardIOCollector.h
+++ b/VGSCardIOCollector/VGSCardIOCollector.h
@@ -1,0 +1,19 @@
+//
+//  VGSCardIOCollector.h
+//  VGSCardIOCollector
+//
+//  Created by Dima on 28.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for VGSCardIOCollector.
+FOUNDATION_EXPORT double VGSCardIOCollectorVersionNumber;
+
+//! Project version string for VGSCardIOCollector.
+FOUNDATION_EXPORT const unsigned char VGSCardIOCollectorVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <VGSCardIOCollector/PublicHeader.h>
+
+

--- a/VGSCardScanCollector/Info.plist
+++ b/VGSCardScanCollector/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/VGSCardScanCollector/VGSCardScanCollector.h
+++ b/VGSCardScanCollector/VGSCardScanCollector.h
@@ -1,0 +1,19 @@
+//
+//  VGSCardScanCollector.h
+//  VGSCardScanCollector
+//
+//  Created by Dima on 18.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for VGSCardScanCollector.
+FOUNDATION_EXPORT double VGSCardScanCollectorVersionNumber;
+
+//! Project version string for VGSCardScanCollector.
+FOUNDATION_EXPORT const unsigned char VGSCardScanCollectorVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <VGSCardScanCollector/PublicHeader.h>
+
+

--- a/VGSCardScanCollectorTests/Info.plist
+++ b/VGSCardScanCollectorTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/VGSCardScanCollectorTests/VGSCardScanCollectorTests.swift
+++ b/VGSCardScanCollectorTests/VGSCardScanCollectorTests.swift
@@ -1,0 +1,34 @@
+//
+//  VGSCardScanCollectorTests.swift
+//  VGSCardScanCollectorTests
+//
+//  Created by Dima on 18.08.2020.
+//  Copyright © 2020 VGS. All rights reserved.
+//
+
+import XCTest
+@testable import VGSCardScanCollector
+
+class VGSCardScanCollectorTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/VGSCollectSDK.podspec
+++ b/VGSCollectSDK.podspec
@@ -22,14 +22,21 @@ Pod::Spec.new do |spec|
   
   spec.subspec 'Core' do |core|
   #set as default podspec to prevent from downloading additional modules
-    core.source_files = "Sources/VGSCollectSDK", "Sources/VGSCollectSDK/**/*.{swift}"
+    core.source_files = "Sources/VGSCollectSDK", "Sources/VGSCollectSDK/**/*.{swift}", "Sources/VGSCollectSDK/**/*.{h, m}"
     core.resource_bundles = {
       'CardIcon' => ['Resources/*']
     }
   end
   
-  spec.subspec 'CardIO' do |cardio|
-    cardio.source_files  = "Sources/VGSCollectSDK", "Sources/VGSCollectSDK/**/*.{h, m}"
-    cardio.dependency "CardIOSDK", "5.5.4"
+  spec.subspec 'CardScan' do |cardscan|
+    cardscan.source_files  = "Sources/VGSCardScanCollector", "Sources/VGSCardScanCollector/**/*.{swift}"
+    cardscan.dependency "VGSCollectSDK/Core"
+    cardscan.dependency "CardScan", "1.0.5045"
+  end
+  
+  spec.subspec 'CardIO' do |cardIO|
+    cardIO.source_files  = "Sources/VGSCardIOCollector", "Sources/VGSCardIOCollector/**/*.{swift}", "Sources/VGSCardIOCollector/**/*.{h, m}"
+    cardIO.dependency "VGSCollectSDK/Core"
+    cardIO.dependency "CardIOSDK", "5.5.4"
   end
 end

--- a/VGSCollectSDK.podspec
+++ b/VGSCollectSDK.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'CardScan' do |cardscan|
     cardscan.source_files  = "Sources/VGSCardScanCollector", "Sources/VGSCardScanCollector/**/*.{swift}"
     cardscan.dependency "VGSCollectSDK/Core"
-    cardscan.dependency "CardScan", "1.0.5045"
+    cardscan.dependency "CardScan", "1.0.5048"
   end
   
   spec.subspec 'CardIO' do |cardIO|

--- a/VGSCollectSDK.xcodeproj/project.pbxproj
+++ b/VGSCollectSDK.xcodeproj/project.pbxproj
@@ -28,10 +28,18 @@
 		324B5E9D24A64A600036867E /* VGSValidationRulePaymentCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 324B5E9C24A64A600036867E /* VGSValidationRulePaymentCard.swift */; };
 		324CDEE323FB12E200653890 /* FilePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 324CDEE123FB12E200653890 /* FilePickerTests.swift */; };
 		325AB9CB2420C5410024134B /* VGSFilePickerControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325AB9CA2420C5410024134B /* VGSFilePickerControllerDelegate.swift */; };
+		3260697D24F7F3F80091F0DD /* CardScan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32CFC72424EBF3B500457B17 /* CardScan.framework */; };
 		3262B2FB23F5A32400D4A73D /* VGSFileSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3262B2F723F5A32400D4A73D /* VGSFileSource.swift */; };
 		3262B2FD23F5A36E00D4A73D /* VGSImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3262B2FC23F5A36E00D4A73D /* VGSImagePicker.swift */; };
 		3262B2FF23F5A3B300D4A73D /* VGSDocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3262B2FE23F5A3B300D4A73D /* VGSDocumentPicker.swift */; };
 		3262B30123F6CBCB00D4A73D /* VGSFilePickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3262B30023F6CBCB00D4A73D /* VGSFilePickerController.swift */; };
+		326FFAF624F904430024A4F9 /* VGSCardIOCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 326FFAF424F904430024A4F9 /* VGSCardIOCollector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		326FFAFE24F908E40024A4F9 /* VGSCardIOHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326FFAFB24F908E30024A4F9 /* VGSCardIOHandler.swift */; };
+		326FFAFF24F908E40024A4F9 /* VGSCardIOScanController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326FFAFC24F908E30024A4F9 /* VGSCardIOScanController.swift */; };
+		326FFB0024F908E40024A4F9 /* VGSCardIOScanControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326FFAFD24F908E30024A4F9 /* VGSCardIOScanControllerDelegate.swift */; };
+		326FFB0424F90B940024A4F9 /* CrardScannerInteractionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326FFB0324F90B940024A4F9 /* CrardScannerInteractionProtocol.swift */; };
+		326FFB0624F90D920024A4F9 /* CardIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 326FFB0524F90D920024A4F9 /* CardIO.framework */; };
+		326FFB0924F90DA00024A4F9 /* VGSCollectSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD12B9AF2304619100B670DD /* VGSCollectSDK.framework */; };
 		3270D3F1248155B200004E3B /* SSNTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3270D3F0248155B200004E3B /* SSNTextFieldTests.swift */; };
 		327C9E142407EF92004C641C /* VGSErrorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327C9E132407EF92004C641C /* VGSErrorInfo.swift */; };
 		327C9E162407F43A004C641C /* VGSErrorInfoKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327C9E152407F43A004C641C /* VGSErrorInfoKey.swift */; };
@@ -42,8 +50,15 @@
 		328A574223FADD3D00714675 /* VGSFilePickerController+internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328A574123FADD3D00714675 /* VGSFilePickerController+internal.swift */; };
 		328B5C7023C8DA2600A39515 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328B5C6F23C8DA2600A39515 /* String+extension.swift */; };
 		328B5C7123C8DA2600A39515 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328B5C6F23C8DA2600A39515 /* String+extension.swift */; };
+		32919C8124FD1EB4002C83D1 /* VGSCardScanControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32919C8024FD1EB4002C83D1 /* VGSCardScanControllerDelegate.swift */; };
 		3299585D23DF043D0018FA50 /* MaskedTextFieldTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3299585C23DF043D0018FA50 /* MaskedTextFieldTest.swift */; };
 		32AFB93724FFD218007FFCAE /* VGSTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AFB93624FFD218007FFCAE /* VGSTextFieldTests.swift */; };
+		32CFC71024EBEEB300457B17 /* VGSCardScanCollector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32CFC70724EBEEB300457B17 /* VGSCardScanCollector.framework */; };
+		32CFC71524EBEEB300457B17 /* VGSCardScanCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CFC71424EBEEB300457B17 /* VGSCardScanCollectorTests.swift */; };
+		32CFC71724EBEEB300457B17 /* VGSCardScanCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CFC70924EBEEB300457B17 /* VGSCardScanCollector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CFC72024EBEFF700457B17 /* VGSCardScanController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CFC71F24EBEFF700457B17 /* VGSCardScanController.swift */; };
+		32CFC72224EBF28B00457B17 /* VGSCardScanHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CFC72124EBF28B00457B17 /* VGSCardScanHandler.swift */; };
+		32CFC72D24EC029800457B17 /* VGSCollectSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD12B9AF2304619100B670DD /* VGSCollectSDK.framework */; };
 		32E4989C23FAEF8300863E61 /* VGSFileInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E4989B23FAEF8300863E61 /* VGSFileInfo.swift */; };
 		32F23A6D24B60E1100E389F7 /* VGSValidationRuleLengthMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F23A6C24B60E1100E389F7 /* VGSValidationRuleLengthMatch.swift */; };
 		32F23A7024B72B7B00E389F7 /* VGSPaymentCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F23A6F24B72B7B00E389F7 /* VGSPaymentCards.swift */; };
@@ -53,9 +68,6 @@
 		32F23A7924B752E200E389F7 /* PaymentCardsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F23A7724B7522000E389F7 /* PaymentCardsTest.swift */; };
 		32F23A7B24B8713A00E389F7 /* CardBrand+default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F23A7A24B8713900E389F7 /* CardBrand+default.swift */; };
 		32F4B7F424C881FA006086F3 /* Calendar+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F4B7F324C881FA006086F3 /* Calendar+extension.swift */; };
-		32FD980823D1FAF9005FA989 /* VGSCardIOScanController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FD980723D1FAF9005FA989 /* VGSCardIOScanController.swift */; };
-		32FD980C23D20E11005FA989 /* VGSCardIOHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FD980B23D20E11005FA989 /* VGSCardIOHandler.swift */; };
-		32FD980E23D5E3A9005FA989 /* VGSCardIOScanControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FD980D23D5E3A9005FA989 /* VGSCardIOScanControllerDelegate.swift */; };
 		FD05F9472316CE5A000EAF52 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD05F9392316CE5A000EAF52 /* Storage.swift */; };
 		FD05F94A2316CE5A000EAF52 /* VGSConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD05F93C2316CE5A000EAF52 /* VGSConfiguration.swift */; };
 		FD05F94C2316CE5A000EAF52 /* VGSCollectSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = FD05F93F2316CE5A000EAF52 /* VGSCollectSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -93,6 +105,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		32CFC71124EBEEB300457B17 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FD12B9A62304619100B670DD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 32CFC70624EBEEB300457B17;
+			remoteInfo = VGSCardScanCollector;
+		};
 		FD2495572330CB49009024E6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FD12B9A62304619100B670DD /* Project object */;
@@ -127,6 +146,14 @@
 		3262B2FC23F5A36E00D4A73D /* VGSImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSImagePicker.swift; sourceTree = "<group>"; };
 		3262B2FE23F5A3B300D4A73D /* VGSDocumentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSDocumentPicker.swift; sourceTree = "<group>"; };
 		3262B30023F6CBCB00D4A73D /* VGSFilePickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSFilePickerController.swift; sourceTree = "<group>"; };
+		326FFAF224F904430024A4F9 /* VGSCardIOCollector.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VGSCardIOCollector.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		326FFAF424F904430024A4F9 /* VGSCardIOCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VGSCardIOCollector.h; sourceTree = "<group>"; };
+		326FFAF524F904430024A4F9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		326FFAFB24F908E30024A4F9 /* VGSCardIOHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSCardIOHandler.swift; sourceTree = "<group>"; };
+		326FFAFC24F908E30024A4F9 /* VGSCardIOScanController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSCardIOScanController.swift; sourceTree = "<group>"; };
+		326FFAFD24F908E30024A4F9 /* VGSCardIOScanControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSCardIOScanControllerDelegate.swift; sourceTree = "<group>"; };
+		326FFB0324F90B940024A4F9 /* CrardScannerInteractionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrardScannerInteractionProtocol.swift; sourceTree = "<group>"; };
+		326FFB0524F90D920024A4F9 /* CardIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CardIO.framework; path = Carthage/Build/iOS/CardIO.framework; sourceTree = "<group>"; };
 		3270D3F0248155B200004E3B /* SSNTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSNTextFieldTests.swift; sourceTree = "<group>"; };
 		327C9E132407EF92004C641C /* VGSErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSErrorInfo.swift; sourceTree = "<group>"; };
 		327C9E152407F43A004C641C /* VGSErrorInfoKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSErrorInfoKey.swift; sourceTree = "<group>"; };
@@ -134,8 +161,18 @@
 		328A573F23FADC3500714675 /* VGSFilePickerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSFilePickerConfiguration.swift; sourceTree = "<group>"; };
 		328A574123FADD3D00714675 /* VGSFilePickerController+internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VGSFilePickerController+internal.swift"; sourceTree = "<group>"; };
 		328B5C6F23C8DA2600A39515 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
+		32919C8024FD1EB4002C83D1 /* VGSCardScanControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardScanControllerDelegate.swift; sourceTree = "<group>"; };
 		3299585C23DF043D0018FA50 /* MaskedTextFieldTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskedTextFieldTest.swift; sourceTree = "<group>"; };
 		32AFB93624FFD218007FFCAE /* VGSTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSTextFieldTests.swift; sourceTree = "<group>"; };
+		32CFC70724EBEEB300457B17 /* VGSCardScanCollector.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VGSCardScanCollector.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		32CFC70924EBEEB300457B17 /* VGSCardScanCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VGSCardScanCollector.h; sourceTree = "<group>"; };
+		32CFC70A24EBEEB300457B17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		32CFC70F24EBEEB300457B17 /* VGSCardScanCollectorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VGSCardScanCollectorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		32CFC71424EBEEB300457B17 /* VGSCardScanCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardScanCollectorTests.swift; sourceTree = "<group>"; };
+		32CFC71624EBEEB300457B17 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		32CFC71F24EBEFF700457B17 /* VGSCardScanController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardScanController.swift; sourceTree = "<group>"; };
+		32CFC72124EBF28B00457B17 /* VGSCardScanHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardScanHandler.swift; sourceTree = "<group>"; };
+		32CFC72424EBF3B500457B17 /* CardScan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CardScan.framework; path = Carthage/Build/iOS/CardScan.framework; sourceTree = "<group>"; };
 		32E4989B23FAEF8300863E61 /* VGSFileInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSFileInfo.swift; sourceTree = "<group>"; };
 		32F23A6C24B60E1100E389F7 /* VGSValidationRuleLengthMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSValidationRuleLengthMatch.swift; sourceTree = "<group>"; };
 		32F23A6F24B72B7B00E389F7 /* VGSPaymentCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSPaymentCards.swift; sourceTree = "<group>"; };
@@ -145,9 +182,6 @@
 		32F23A7724B7522000E389F7 /* PaymentCardsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCardsTest.swift; sourceTree = "<group>"; };
 		32F23A7A24B8713900E389F7 /* CardBrand+default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardBrand+default.swift"; sourceTree = "<group>"; };
 		32F4B7F324C881FA006086F3 /* Calendar+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+extension.swift"; sourceTree = "<group>"; };
-		32FD980723D1FAF9005FA989 /* VGSCardIOScanController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardIOScanController.swift; sourceTree = "<group>"; };
-		32FD980B23D20E11005FA989 /* VGSCardIOHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardIOHandler.swift; sourceTree = "<group>"; };
-		32FD980D23D5E3A9005FA989 /* VGSCardIOScanControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardIOScanControllerDelegate.swift; sourceTree = "<group>"; };
 		FD05F9392316CE5A000EAF52 /* Storage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		FD05F93A2316CE5A000EAF52 /* Enums.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		FD05F93B2316CE5A000EAF52 /* VGSCollect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VGSCollect.swift; sourceTree = "<group>"; };
@@ -189,6 +223,32 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		326FFAEF24F904430024A4F9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				326FFB0624F90D920024A4F9 /* CardIO.framework in Frameworks */,
+				326FFB0924F90DA00024A4F9 /* VGSCollectSDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70424EBEEB300457B17 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32CFC72D24EC029800457B17 /* VGSCollectSDK.framework in Frameworks */,
+				3260697D24F7F3F80091F0DD /* CardScan.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70C24EBEEB300457B17 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32CFC71024EBEEB300457B17 /* VGSCardScanCollector.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD12B9AC2304619100B670DD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -257,6 +317,78 @@
 			path = Analytics;
 			sourceTree = "<group>";
 		};
+		326FFAF324F904430024A4F9 /* VGSCardIOCollector */ = {
+			isa = PBXGroup;
+			children = (
+				326FFAF424F904430024A4F9 /* VGSCardIOCollector.h */,
+				326FFAF524F904430024A4F9 /* Info.plist */,
+			);
+			path = VGSCardIOCollector;
+			sourceTree = "<group>";
+		};
+		326FFAFA24F908AB0024A4F9 /* VGSCardIOCollector */ = {
+			isa = PBXGroup;
+			children = (
+				326FFAFB24F908E30024A4F9 /* VGSCardIOHandler.swift */,
+				326FFAFC24F908E30024A4F9 /* VGSCardIOScanController.swift */,
+				326FFAFD24F908E30024A4F9 /* VGSCardIOScanControllerDelegate.swift */,
+			);
+			path = VGSCardIOCollector;
+			sourceTree = "<group>";
+		};
+		326FFB0124F90B270024A4F9 /* Integrations */ = {
+			isa = PBXGroup;
+			children = (
+				326FFB0224F90B6D0024A4F9 /* CardScanners */,
+			);
+			path = Integrations;
+			sourceTree = "<group>";
+		};
+		326FFB0224F90B6D0024A4F9 /* CardScanners */ = {
+			isa = PBXGroup;
+			children = (
+				326FFB0324F90B940024A4F9 /* CrardScannerInteractionProtocol.swift */,
+			);
+			path = CardScanners;
+			sourceTree = "<group>";
+		};
+		32CFC70824EBEEB300457B17 /* VGSCardScanCollector */ = {
+			isa = PBXGroup;
+			children = (
+				32CFC70924EBEEB300457B17 /* VGSCardScanCollector.h */,
+				32CFC70A24EBEEB300457B17 /* Info.plist */,
+			);
+			path = VGSCardScanCollector;
+			sourceTree = "<group>";
+		};
+		32CFC71324EBEEB300457B17 /* VGSCardScanCollectorTests */ = {
+			isa = PBXGroup;
+			children = (
+				32CFC71424EBEEB300457B17 /* VGSCardScanCollectorTests.swift */,
+				32CFC71624EBEEB300457B17 /* Info.plist */,
+			);
+			path = VGSCardScanCollectorTests;
+			sourceTree = "<group>";
+		};
+		32CFC71E24EBEF0E00457B17 /* VGSCardScanCollector */ = {
+			isa = PBXGroup;
+			children = (
+				32CFC72124EBF28B00457B17 /* VGSCardScanHandler.swift */,
+				32CFC71F24EBEFF700457B17 /* VGSCardScanController.swift */,
+				32919C8024FD1EB4002C83D1 /* VGSCardScanControllerDelegate.swift */,
+			);
+			path = VGSCardScanCollector;
+			sourceTree = "<group>";
+		};
+		32CFC72324EBF3B500457B17 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				326FFB0524F90D920024A4F9 /* CardIO.framework */,
+				32CFC72424EBF3B500457B17 /* CardScan.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		32F23A6E24B72B6A00E389F7 /* PaymentCards */ = {
 			isa = PBXGroup;
 			children = (
@@ -269,30 +401,12 @@
 			path = PaymentCards;
 			sourceTree = "<group>";
 		};
-		32FD980523D1FA48005FA989 /* Integrations */ = {
-			isa = PBXGroup;
-			children = (
-				32FD980623D1FA7B005FA989 /* CardIO */,
-			);
-			path = Integrations;
-			sourceTree = "<group>";
-		};
-		32FD980623D1FA7B005FA989 /* CardIO */ = {
-			isa = PBXGroup;
-			children = (
-				32FD980723D1FAF9005FA989 /* VGSCardIOScanController.swift */,
-				32FD980B23D20E11005FA989 /* VGSCardIOHandler.swift */,
-				32FD980D23D5E3A9005FA989 /* VGSCardIOScanControllerDelegate.swift */,
-			);
-			path = CardIO;
-			sourceTree = "<group>";
-		};
 		FD05F9372316CE5A000EAF52 /* VGSCollectSDK */ = {
 			isa = PBXGroup;
 			children = (
 				FD05F9382316CE5A000EAF52 /* Core */,
-				32FD980523D1FA48005FA989 /* Integrations */,
 				FD05F9432316CE5A000EAF52 /* UIElements */,
+				326FFB0124F90B270024A4F9 /* Integrations */,
 				FD05F93F2316CE5A000EAF52 /* VGSCollectSDK.h */,
 				FD05F9402316CE5A000EAF52 /* Info.plist */,
 			);
@@ -335,7 +449,11 @@
 				FDE7447B238A5C79003AA46B /* Resources */,
 				FD8A9722233CF63D0079FA32 /* Sources */,
 				FD8A9723233CF6470079FA32 /* Tests */,
+				32CFC70824EBEEB300457B17 /* VGSCardScanCollector */,
+				32CFC71324EBEEB300457B17 /* VGSCardScanCollectorTests */,
+				326FFAF324F904430024A4F9 /* VGSCardIOCollector */,
 				FD12B9B02304619100B670DD /* Products */,
+				32CFC72324EBF3B500457B17 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -344,6 +462,9 @@
 			children = (
 				FD12B9AF2304619100B670DD /* VGSCollectSDK.framework */,
 				FD2495512330CB49009024E6 /* FrameworkTests.xctest */,
+				32CFC70724EBEEB300457B17 /* VGSCardScanCollector.framework */,
+				32CFC70F24EBEEB300457B17 /* VGSCardScanCollectorTests.xctest */,
+				326FFAF224F904430024A4F9 /* VGSCardIOCollector.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -420,6 +541,8 @@
 			isa = PBXGroup;
 			children = (
 				FD05F9372316CE5A000EAF52 /* VGSCollectSDK */,
+				326FFAFA24F908AB0024A4F9 /* VGSCardIOCollector */,
+				32CFC71E24EBEF0E00457B17 /* VGSCardScanCollector */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -491,6 +614,22 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		326FFAED24F904430024A4F9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				326FFAF624F904430024A4F9 /* VGSCardIOCollector.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70224EBEEB300457B17 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32CFC71724EBEEB300457B17 /* VGSCardScanCollector.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD12B9AA2304619100B670DD /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -502,6 +641,62 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		326FFAF124F904430024A4F9 /* VGSCardIOCollector */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 326FFAF924F904430024A4F9 /* Build configuration list for PBXNativeTarget "VGSCardIOCollector" */;
+			buildPhases = (
+				326FFAED24F904430024A4F9 /* Headers */,
+				326FFAEE24F904430024A4F9 /* Sources */,
+				326FFAEF24F904430024A4F9 /* Frameworks */,
+				326FFAF024F904430024A4F9 /* Resources */,
+				326FFB0E24F90DB60024A4F9 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VGSCardIOCollector;
+			productName = VGSCardIOCollector;
+			productReference = 326FFAF224F904430024A4F9 /* VGSCardIOCollector.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		32CFC70624EBEEB300457B17 /* VGSCardScanCollector */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 32CFC71C24EBEEB300457B17 /* Build configuration list for PBXNativeTarget "VGSCardScanCollector" */;
+			buildPhases = (
+				32CFC70224EBEEB300457B17 /* Headers */,
+				32CFC70324EBEEB300457B17 /* Sources */,
+				32CFC70424EBEEB300457B17 /* Frameworks */,
+				32CFC70524EBEEB300457B17 /* Resources */,
+				32CFC72824EBF3BC00457B17 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VGSCardScanCollector;
+			productName = VGSCardScanCollector;
+			productReference = 32CFC70724EBEEB300457B17 /* VGSCardScanCollector.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		32CFC70E24EBEEB300457B17 /* VGSCardScanCollectorTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 32CFC71D24EBEEB300457B17 /* Build configuration list for PBXNativeTarget "VGSCardScanCollectorTests" */;
+			buildPhases = (
+				32CFC70B24EBEEB300457B17 /* Sources */,
+				32CFC70C24EBEEB300457B17 /* Frameworks */,
+				32CFC70D24EBEEB300457B17 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				32CFC71224EBEEB300457B17 /* PBXTargetDependency */,
+			);
+			name = VGSCardScanCollectorTests;
+			productName = VGSCardScanCollectorTests;
+			productReference = 32CFC70F24EBEEB300457B17 /* VGSCardScanCollectorTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		FD12B9AE2304619100B670DD /* VGSCollectSDK */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FD12B9C32304619200B670DD /* Build configuration list for PBXNativeTarget "VGSCollectSDK" */;
@@ -544,10 +739,21 @@
 		FD12B9A62304619100B670DD /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1140;
+				LastSwiftUpdateCheck = 1160;
 				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = VGS;
 				TargetAttributes = {
+					326FFAF124F904430024A4F9 = {
+						CreatedOnToolsVersion = 11.6;
+						LastSwiftMigration = 1160;
+					};
+					32CFC70624EBEEB300457B17 = {
+						CreatedOnToolsVersion = 11.6;
+						LastSwiftMigration = 1160;
+					};
+					32CFC70E24EBEEB300457B17 = {
+						CreatedOnToolsVersion = 11.6;
+					};
 					FD12B9AE2304619100B670DD = {
 						CreatedOnToolsVersion = 10.3;
 						LastSwiftMigration = 1130;
@@ -573,11 +779,35 @@
 			targets = (
 				FD12B9AE2304619100B670DD /* VGSCollectSDK */,
 				FD2495502330CB49009024E6 /* FrameworkTests */,
+				32CFC70624EBEEB300457B17 /* VGSCardScanCollector */,
+				32CFC70E24EBEEB300457B17 /* VGSCardScanCollectorTests */,
+				326FFAF124F904430024A4F9 /* VGSCardIOCollector */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		326FFAF024F904430024A4F9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70524EBEEB300457B17 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70D24EBEEB300457B17 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD12B9AD2304619100B670DD /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -596,7 +826,76 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		326FFB0E24F90DB60024A4F9 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/CardIO.framework",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/CardIO.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+		32CFC72824EBF3BC00457B17 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/CardScan.framework",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/CardScan.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		326FFAEE24F904430024A4F9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				326FFAFE24F908E40024A4F9 /* VGSCardIOHandler.swift in Sources */,
+				326FFB0024F908E40024A4F9 /* VGSCardIOScanControllerDelegate.swift in Sources */,
+				326FFAFF24F908E40024A4F9 /* VGSCardIOScanController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70324EBEEB300457B17 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32CFC72224EBF28B00457B17 /* VGSCardScanHandler.swift in Sources */,
+				32919C8124FD1EB4002C83D1 /* VGSCardScanControllerDelegate.swift in Sources */,
+				32CFC72024EBEFF700457B17 /* VGSCardScanController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		32CFC70B24EBEEB300457B17 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32CFC71524EBEEB300457B17 /* VGSCardScanCollectorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FD12B9AB2304619100B670DD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -619,9 +918,9 @@
 				32F23A7B24B8713A00E389F7 /* CardBrand+default.swift in Sources */,
 				32F23A7424B72C4500E389F7 /* VGSCustomPaymentCardModel.swift in Sources */,
 				FD6F5657238E7FBB00C24123 /* CardType+icon.swift in Sources */,
-				32FD980C23D20E11005FA989 /* VGSCardIOHandler.swift in Sources */,
 				FD1489FC232D4F6B00FD7781 /* APIClient.swift in Sources */,
 				FD3C01C323AFC0980096B4A4 /* VGSTextField+CVC.swift in Sources */,
+				326FFB0424F90B940024A4F9 /* CrardScannerInteractionProtocol.swift in Sources */,
 				FD8B62472497CD580097C9AB /* VGSExpDateTextField.swift in Sources */,
 				FD1B44612327A6C6009AA04A /* VGSCollect+extension.swift in Sources */,
 				3262B2FD23F5A36E00D4A73D /* VGSImagePicker.swift in Sources */,
@@ -644,13 +943,11 @@
 				328A574223FADD3D00714675 /* VGSFilePickerController+internal.swift in Sources */,
 				FD1489FF232D4F8000FD7781 /* MaskedTextField.swift in Sources */,
 				320E885323A94E1800A9C1FA /* CharacterSet+extension.swift in Sources */,
-				32FD980823D1FAF9005FA989 /* VGSCardIOScanController.swift in Sources */,
 				FD4ED0E623736BB100AEAD24 /* MaskedTextField+security.swift in Sources */,
 				3262B30123F6CBCB00D4A73D /* VGSFilePickerController.swift in Sources */,
 				324B5E7324A23F6B0036867E /* VGSValidationRuleLuhnCheck.swift in Sources */,
 				FD148A07232EC53600FD7781 /* State.swift in Sources */,
 				324B5E6D24A23CC50036867E /* VGSValidationError.swift in Sources */,
-				32FD980E23D5E3A9005FA989 /* VGSCardIOScanControllerDelegate.swift in Sources */,
 				321300192417F2E80062FEF0 /* VGSCollect+internal.swift in Sources */,
 				32E4989C23FAEF8300863E61 /* VGSFileInfo.swift in Sources */,
 			);
@@ -693,6 +990,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		32CFC71224EBEEB300457B17 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 32CFC70624EBEEB300457B17 /* VGSCardScanCollector */;
+			targetProxy = 32CFC71124EBEEB300457B17 /* PBXContainerItemProxy */;
+		};
 		FD2495582330CB49009024E6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FD12B9AE2304619100B670DD /* VGSCollectSDK */;
@@ -701,6 +1003,172 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		326FFAF724F904430024A4F9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = RV64AU4P26;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = VGSCardIOCollector/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vgs.framework.VGSCardIOCollector;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		326FFAF824F904430024A4F9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = RV64AU4P26;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = VGSCardIOCollector/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vgs.framework.VGSCardIOCollector;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		32CFC71824EBEEB300457B17 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = VGSCardScanCollector/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vgs.framework.VGSCardScanCollector;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		32CFC71924EBEEB300457B17 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = VGSCardScanCollector/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vgs.framework.VGSCardScanCollector;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		32CFC71A24EBEEB300457B17 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = RV64AU4P26;
+				INFOPLIST_FILE = VGSCardScanCollectorTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vgs.io.VGSCardScanCollectorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		32CFC71B24EBEEB300457B17 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = RV64AU4P26;
+				INFOPLIST_FILE = VGSCardScanCollectorTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vgs.io.VGSCardScanCollectorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		FD12B9C12304619200B670DD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -941,6 +1409,33 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		326FFAF924F904430024A4F9 /* Build configuration list for PBXNativeTarget "VGSCardIOCollector" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				326FFAF724F904430024A4F9 /* Debug */,
+				326FFAF824F904430024A4F9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		32CFC71C24EBEEB300457B17 /* Build configuration list for PBXNativeTarget "VGSCardScanCollector" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				32CFC71824EBEEB300457B17 /* Debug */,
+				32CFC71924EBEEB300457B17 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		32CFC71D24EBEEB300457B17 /* Build configuration list for PBXNativeTarget "VGSCardScanCollectorTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				32CFC71A24EBEEB300457B17 /* Debug */,
+				32CFC71B24EBEEB300457B17 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FD12B9A92304619100B670DD /* Build configuration list for PBXProject "VGSCollectSDK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/VGSCollectSDK.xcodeproj/xcshareddata/xcschemes/VGSCardIOCollector.xcscheme
+++ b/VGSCollectSDK.xcodeproj/xcshareddata/xcschemes/VGSCardIOCollector.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "326FFAF124F904430024A4F9"
+               BuildableName = "VGSCardIOCollector.framework"
+               BlueprintName = "VGSCardIOCollector"
+               ReferencedContainer = "container:VGSCollectSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "326FFAF124F904430024A4F9"
+            BuildableName = "VGSCardIOCollector.framework"
+            BlueprintName = "VGSCardIOCollector"
+            ReferencedContainer = "container:VGSCollectSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/VGSCollectSDK.xcodeproj/xcshareddata/xcschemes/VGSCardScanCollector.xcscheme
+++ b/VGSCollectSDK.xcodeproj/xcshareddata/xcschemes/VGSCardScanCollector.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "32CFC70624EBEEB300457B17"
+               BuildableName = "VGSCardScanCollector.framework"
+               BlueprintName = "VGSCardScanCollector"
+               ReferencedContainer = "container:VGSCollectSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "32CFC70E24EBEEB300457B17"
+               BuildableName = "VGSCardScanCollectorTests.xctest"
+               BlueprintName = "VGSCardScanCollectorTests"
+               ReferencedContainer = "container:VGSCollectSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32CFC70624EBEEB300457B17"
+            BuildableName = "VGSCardScanCollector.framework"
+            BlueprintName = "VGSCardScanCollector"
+            ReferencedContainer = "container:VGSCollectSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/demoapp/Podfile
+++ b/demoapp/Podfile
@@ -8,6 +8,7 @@ target 'demoapp' do
 
 #  pod 'VGSCollectSDK'
   pod 'VGSCollectSDK', :path => "../"
+  pod 'VGSCollectSDK/CardScan', :path => "../"
   pod 'VGSCollectSDK/CardIO', :path => "../"
 
 end

--- a/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
+++ b/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
@@ -29,8 +29,8 @@ class CardsDataCollectingViewController: UIViewController {
         didSet { consoleLabel.text = consoleMessage }
     }
     
-    // Init CardIO Scan controller
-    var scanController = VGSCardIOScanController()
+    // Init CardScan controller with API KEY. Details: https://cardscan.io
+    var scanController = VGSCardScanController(apiKey: "YOUR_CARD_SCAN_API_KEY")
     
 
     override func viewDidLoad() {
@@ -50,9 +50,7 @@ class CardsDataCollectingViewController: UIViewController {
         ]
 
         
-        // set preferred device camera
-//        scanController.preferredCameraPosition = .front
-        // set VGSCardIOScanDelegate
+        // set VGSCardScanDelegate
         scanController.delegate = self
 
         // Observing text fields. The call back return all textfields with updated states. You also can use VGSTextFieldDelegate
@@ -173,9 +171,15 @@ class CardsDataCollectingViewController: UIViewController {
         }
     }
     
-    // Start CardIO scanning
+    // Start CardScan scanning
     @IBAction func scanAction(_ sender: Any) {
+      
+      /// Check if CardScan can run on current device
+      if VGSCardScanController.isCompatible() {
         scanController.presentCardScanner(on: self, animated: true, completion: nil)
+      } else {
+        print("This device not compatible with CardScan")
+      }
     }
     
     // Upload data from TextFields to VGS
@@ -223,35 +227,7 @@ class CardsDataCollectingViewController: UIViewController {
     }
 }
 
-extension CardsDataCollectingViewController: VGSCardIOScanControllerDelegate {
-    
-    //When user press Done button on CardIO screen
-    func userDidFinishScan() {
-        scanController.dismissCardScanner(animated: true, completion: {
-            // add actions on scan controller dismiss completion
-        })
-    }
-    
-    //When user press Cancel button on CardIO screen
-    func userDidCancelScan() {
-        scanController.dismissCardScanner(animated: true, completion: nil)
-    }
-    
-    //Asks VGSTextField where scanned data with type need to be set.
-    func textFieldForScannedData(type: CradIODataType) -> VGSTextField? {
-        switch type {
-        case .expirationDateLong:
-            return expCardDate
-        case .cvc:
-            return cvcCardNum
-        case .cardNumber:
-            return cardNumber
-        default:
-            return nil
-        }
-    }
-}
-
+// MARK: - VGSTextFieldDelegate
 extension CardsDataCollectingViewController: VGSTextFieldDelegate {
   func vgsTextFieldDidChange(_ textField: VGSTextField) {
     print(textField.state.description)
@@ -267,4 +243,34 @@ extension CardsDataCollectingViewController: VGSTextFieldDelegate {
         print("THIS IS: \(cardState.cardBrand.stringValue) - \(cardState.bin.prefix(4)) **** **** \(cardState.last4)")
     }
   }
+}
+
+// MARK: - VGSCardScanControllerDelegate
+extension CardsDataCollectingViewController: VGSCardScanControllerDelegate {
+    
+    //After User did finish scanning on Card Scan screen
+    func userDidFinishScan() {
+        scanController.dismissCardScanner(animated: true, completion: {
+            // add actions on scan controller dismiss completion
+        })
+    }
+    
+    //When user press Back/Cancel button on Card Scan screen
+    func userDidCancelScan() {
+        scanController.dismissCardScanner(animated: true, completion: nil)
+    }
+    
+    //Asks VGSTextField where scanned data with type need to be set.
+    func textFieldForScannedData(type: CradScanDataType) -> VGSTextField? {
+        switch type {
+        case .expirationDateLong:
+            return expCardDate
+        case .name:
+            return cardHolderName
+        case .cardNumber:
+            return cardNumber
+        default:
+            return nil
+        }
+    }
 }

--- a/demoapp/demoappUITests/TestCollectCardsDataFlow.swift
+++ b/demoapp/demoappUITests/TestCollectCardsDataFlow.swift
@@ -10,7 +10,8 @@ import XCTest
 @testable import demoapp
 
 class TestCollectCardsDataFlow: XCTestCase {
-
+    let flowType = "Collect Payment Cards"
+  
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
@@ -73,47 +74,22 @@ class TestCollectCardsDataFlow: XCTestCase {
       XCTAssert(successResponseLabel.exists)
     }
   
-  
-  func testValidInputThroughCardIO() {
-      let app = XCUIApplication()
-      app.navigationBars["Demo"].buttons["VaultID"].tap()
-      app.alerts["Set <vault id>"].waitForExistence(timeout: 2)
-      app.alerts["Set <vault id>"].scrollViews.otherElements.collectionViews/*@START_MENU_TOKEN@*/.buttons["Clear text"]/*[[".cells",".textFields.buttons[\"Clear text\"]",".buttons[\"Clear text\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.tap()
-      app.alerts["Set <vault id>"].typeText("tntva5wfdrp")
-      app.alerts["Set <vault id>"].scrollViews.otherElements.buttons["Save"].tap()
-      app.tables.staticTexts["Collect Payment Cards Data"].tap()
+  func testCardScan() {
+    let app = XCUIApplication()
+    app.navigationBars["Demo"].buttons["VaultID"].tap()
+    app.alerts["Set <vault id>"].waitForExistence(timeout: 2)
+    app.alerts["Set <vault id>"].scrollViews.otherElements.collectionViews/*@START_MENU_TOKEN@*/.buttons["Clear text"]/*[[".cells",".textFields.buttons[\"Clear text\"]",".buttons[\"Clear text\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.tap()
+    app.alerts["Set <vault id>"].typeText("tntva5wfdrp")
+    app.alerts["Set <vault id>"].scrollViews.otherElements.buttons["Save"].tap()
+    app.tables.staticTexts["Collect Payment Cards Data"].tap()
+    app.staticTexts["STATE"].tap()
     
-      let cardHolderNameField = app.textFields["Cardholder Name"]
-      
-      cardHolderNameField.tap()
-      cardHolderNameField.typeText("Joe B")
-
-      app.staticTexts["STATE"].tap()
-    
-      app.buttons["SCAN"].tap()
-      let cardIOCardNumField =  app.tables.textFields["Card Number"]
-      let cardIOExpDateField =  app.tables.textFields["MM / YY"]
-      let cardIOCVVField =  app.tables.textFields["CVV"]
-     
-
-      cardIOCardNumField.tap()
-      cardIOCardNumField.typeText("4111111111111111")
-    
-      cardIOExpDateField.tap()
-      cardIOExpDateField.typeText("0130")
-
-      cardIOCVVField.tap()
-      cardIOCVVField.typeText("123")
-    
-      app.navigationBars["Card"].buttons["Done"].tap()
-            
-      app.buttons["UPLOAD"].tap()
-      let responseLabel = app.staticTexts["RESPONSE"]
-      responseLabel.waitForExistence(timeout: 30)
-      
-      let successResponsePredicate = NSPredicate(format: "label BEGINSWITH 'Success: '")
-      let successResponseLabel = app.staticTexts.element(matching: successResponsePredicate)
-      XCTAssert(successResponseLabel.exists)
+    app.buttons["SCAN"].tap()
+    let popup = app.alerts["“demoapp” Would Like to Access the Camera"]
+    if popup.exists {
+      popup.buttons["OK"].tap()
+    }
+    app.buttons["Back"].tap()
   }
 }
 

--- a/demoapp/demoappUITests/TestCustomCardNumbersDataFlow.swift
+++ b/demoapp/demoappUITests/TestCustomCardNumbersDataFlow.swift
@@ -112,4 +112,46 @@ class TestCustomCardNumbersDataFlow: XCTestCase {
      XCTAssert(successResponseLabel.exists)
     
   }
+  
+  func testValidInputThroughCardIO() {
+      let app = XCUIApplication()
+      app.navigationBars["Demo"].buttons["VaultID"].tap()
+      app.alerts["Set <vault id>"].waitForExistence(timeout: 2)
+      app.alerts["Set <vault id>"].scrollViews.otherElements.collectionViews/*@START_MENU_TOKEN@*/.buttons["Clear text"]/*[[".cells",".textFields.buttons[\"Clear text\"]",".buttons[\"Clear text\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.tap()
+      app.alerts["Set <vault id>"].typeText("tntva5wfdrp")
+      app.alerts["Set <vault id>"].scrollViews.otherElements.buttons["Save"].tap()
+      app.tables.staticTexts[flowType].tap()
+    
+      let cardHolderNameField = app.textFields["Cardholder Name"]
+      
+      cardHolderNameField.tap()
+      cardHolderNameField.typeText("Joe B")
+
+      app.staticTexts["STATE"].tap()
+    
+      app.buttons["SCAN"].tap()
+      let cardIOCardNumField =  app.tables.textFields["Card Number"]
+      let cardIOExpDateField =  app.tables.textFields["MM / YY"]
+      let cardIOCVVField =  app.tables.textFields["CVV"]
+     
+
+      cardIOCardNumField.tap()
+      cardIOCardNumField.typeText("4111111111111111")
+    
+      cardIOExpDateField.tap()
+      cardIOExpDateField.typeText("0130")
+
+      cardIOCVVField.tap()
+      cardIOCVVField.typeText("123")
+    
+      app.navigationBars["Card"].buttons["Done"].tap()
+            
+      app.buttons["UPLOAD"].tap()
+      let responseLabel = app.staticTexts["RESPONSE"]
+      responseLabel.waitForExistence(timeout: 30)
+      
+      let successResponsePredicate = NSPredicate(format: "label BEGINSWITH 'Success: '")
+      let successResponseLabel = app.staticTexts.element(matching: successResponsePredicate)
+      XCTAssert(successResponseLabel.exists)
+  }
 }


### PR DESCRIPTION
## Fixes [IOSSDK-22] Add new optional scan modules

## Description of changes
Added new scan module that works with CardScan(Bouncer). Make scan modules integration optional.

## Value being added
(insert text here)

## Testing
Integrate VGSCollectSDK/CardScan pod.


[IOSSDK-22]: https://verygoodsecurity.atlassian.net/browse/IOSSDK-22