### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "VGSCollectSDK",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "VGSCollectSDK",
+            targets: ["VGSCollectSDK"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "VGSCollectSDK",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "FrameworkTests",
+            dependencies: ["VGSCollectSDK"]
+        )
+    ]
+)

--- a/Sources/VGSCollectSDK/Core/PaymentCards/VGSCustomPaymentCardModel.swift
+++ b/Sources/VGSCollectSDK/Core/PaymentCards/VGSCustomPaymentCardModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public struct VGSCustomPaymentCardModel: VGSPaymentCardModelProtocol {
   

--- a/Sources/VGSCollectSDK/Core/PaymentCards/VGSPaymentCardModel.swift
+++ b/Sources/VGSCollectSDK/Core/PaymentCards/VGSPaymentCardModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// :nodoc: Payment Card Model Protocol
 public protocol VGSPaymentCardModelProtocol {

--- a/Sources/VGSCollectSDK/Core/PaymentCards/VGSUnknownPaymentCardModel.swift
+++ b/Sources/VGSCollectSDK/Core/PaymentCards/VGSUnknownPaymentCardModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 
 /// An object representing Unknown Payment Cards - cards not defined in the SDK. Object is used when validation for`CardBrand.unknown` is set as `true`. Check `VGSValidationRulePaymentCard` for more details. Validation attributes can be edited through ``VGSPaymentCards.unknown` model.

--- a/Sources/VGSCollectSDK/UIElements/FilePicker/VGSDocumentPicker.swift
+++ b/Sources/VGSCollectSDK/UIElements/FilePicker/VGSDocumentPicker.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import MobileCoreServices
 
 /// A class that manage UIDocumentPickerViewController

--- a/Sources/VGSCollectSDK/UIElements/FilePicker/VGSFilePickerController+internal.swift
+++ b/Sources/VGSCollectSDK/UIElements/FilePicker/VGSFilePickerController+internal.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 internal protocol VGSFilePickerProtocol {
     var delegate: VGSFilePickerControllerDelegate? { get set }

--- a/Sources/VGSCollectSDK/UIElements/FilePicker/VGSFilePickerController.swift
+++ b/Sources/VGSCollectSDK/UIElements/FilePicker/VGSFilePickerController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// Controller responsible for importing files from device sources.
 public class VGSFilePickerController {

--- a/Sources/VGSCollectSDK/UIElements/FilePicker/VGSImagePicker.swift
+++ b/Sources/VGSCollectSDK/UIElements/FilePicker/VGSImagePicker.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 VGS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// A class that manage UIImagePickerController
 internal class VGSImagePicker: NSObject, VGSFilePickerProtocol {


### PR DESCRIPTION
Dropped iOS v10 due to JSON serialization compilation error.. see `Dictionary.jsonStringRepresentation` util.
