### PR TITLE
Unassign textfields from VGSCollect instance.

### DIFF
--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect.swift
@@ -77,15 +77,33 @@ public class VGSCollect {
       self.init(id: id, environment: env)
     }
 
-    // MARK: - Helper functions
-    
-    /// Detach files for associated `VGSCollect` instance.
-    public func cleanFiles() {
-        storage.removeFiles()
-    }
+    // MARK: - Manage VGSTextFields
     
     /// Returns `VGSTextField` with `VGSConfiguration.fieldName` associated with `VGCollect` instance.
     public func getTextField(fieldName: String) -> VGSTextField? {
         return storage.elements.first(where: { $0.fieldName == fieldName })
+    }
+  
+    /// Unassign `VGSTextField` from `VGSCollect` instance
+    ///
+    /// - Parameters:
+    ///   - textField: `VGSTextField` that should be unassigned.
+    public func unassignTextField(_ textField: VGSTextField) {
+      self.unregisterTextFields(textField: [textField])
+    }
+  
+    /// Unassign `VGSTextField`s from `VGSCollect` instance
+    ///
+    /// - Parameters:
+    ///   - textFields: an array of `VGSTextField`s that should be unassigned.
+    public func unassignTextFields(_ textFields: [VGSTextField]) {
+      self.unregisterTextFields(textField: textFields)
+    }
+  
+    // MARK: - Manage Filesb
+  
+    /// Detach files for associated `VGSCollect` instance.
+    public func cleanFiles() {
+        storage.removeFiles()
     }
 }

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect.swift
@@ -20,12 +20,12 @@ public class VGSCollect {
   
     /// Max file size limit by proxy. Is static and can't be changed!
     internal let maxFileSizeInternalLimitInBytes = 24_000_000
-    /// Unique form identifier
+    /// Unique form identifier.
     internal let formId = UUID().uuidString
       
     // MARK: Custom HTTP Headers
     
-    /// Set your custom HTTP headers
+    /// Set your custom HTTP headers.
     public var customHeaders: [String: String]? {
         didSet {
             if customHeaders != oldValue {
@@ -52,7 +52,7 @@ public class VGSCollect {
   
     // MARK: - Initialzation
     
-    /// Initialzation
+    /// Initialzation.
     ///
     /// - Parameters:
     ///   - id: your organization vault id.
@@ -66,7 +66,7 @@ public class VGSCollect {
   
     // MARK: - Initialzation
     
-    /// Initialzation
+    /// Initialzation.
     ///
     /// - Parameters:
     ///   - id: your organization vault id.
@@ -84,7 +84,7 @@ public class VGSCollect {
         return storage.elements.first(where: { $0.fieldName == fieldName })
     }
   
-    /// Unassign `VGSTextField` from `VGSCollect` instance
+    /// Unassign `VGSTextField` from `VGSCollect` instance.
     ///
     /// - Parameters:
     ///   - textField: `VGSTextField` that should be unassigned.
@@ -92,7 +92,7 @@ public class VGSCollect {
       self.unregisterTextFields(textField: [textField])
     }
   
-    /// Unassign `VGSTextField`s from `VGSCollect` instance
+    /// Unassign `VGSTextField`s from `VGSCollect` instance.
     ///
     /// - Parameters:
     ///   - textFields: an array of `VGSTextField`s that should be unassigned.
@@ -100,7 +100,7 @@ public class VGSCollect {
       self.unregisterTextFields(textField: textFields)
     }
   
-    // MARK: - Manage Filesb
+    // MARK: - Manage Files
   
     /// Detach files for associated `VGSCollect` instance.
     public func cleanFiles() {

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
@@ -135,7 +135,6 @@ public class VGSTextField: UIView {
     }
     
     deinit {
-        vgsCollector?.unregisterTextFields(textField: [self])
         NotificationCenter.default.removeObserver(self)
     }
   

--- a/Tests/FrameworkTests/VGSCollectTests.swift
+++ b/Tests/FrameworkTests/VGSCollectTests.swift
@@ -156,6 +156,40 @@ class VGSCollectTests: XCTestCase {
       XCTAssertTrue(collector.storage.elements.count == 0)
       XCTAssertTrue(collector.textFields.count == 0)
   }
+  
+    func testUnassignSingleTextField() {
+        let config = VGSConfiguration(collector: collector, fieldName: "test")
+        let tf1 = VGSCardTextField()
+        tf1.configuration = config
+        
+        XCTAssertTrue(collector.storage.elements.count == 1)
+        XCTAssertTrue(collector.textFields.count == 1)
+      
+        collector.unassignTextField(tf1)
+        
+        XCTAssertTrue(collector.storage.elements.count == 0)
+        XCTAssertTrue(collector.textFields.count == 0)
+      
+        collector.unassignTextField(tf1)
+        XCTAssertTrue(collector.storage.elements.count == 0)
+        XCTAssertTrue(collector.textFields.count == 0)
+    }
+  
+    func testUnassignMultipleTextFields() {
+      let config = VGSConfiguration(collector: collector, fieldName: "test")
+      let tf2 = VGSTextField()
+      tf2.configuration = config
+    
+      let tf3 = VGSExpDateTextField()
+      tf3.configuration = config
+    
+      XCTAssertTrue(collector.storage.elements.count == 2)
+      XCTAssertTrue(collector.textFields.count == 2)
+      
+      collector.unassignTextFields([tf3, tf2])
+      XCTAssertTrue(collector.storage.elements.count == 0)
+      XCTAssertTrue(collector.textFields.count == 0)
+    }
     
     func testCustomJsonMapping() {
         let cardConfiguration = VGSConfiguration(collector: collector, fieldName: "user.card_data.card_number")


### PR DESCRIPTION
## Fixes [iOSSDK-81]

## Description of changes
Manually unassign textfields from VGSCollect instance.

## Value being added
This will allow to get read from memory leaks when collect instance reused multiple times.

## Testing
(insert text here)
