### PR TITLE
Add error when month not valid in VGSValidationRuleCardExpirationDate

### DIFF
--- a/Sources/VGSCollectSDK/UIElements/Text Field/Validation/Date/VGSValidationRuleExpirationDate.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Validation/Date/VGSValidationRuleExpirationDate.swift
@@ -60,7 +60,6 @@ public struct VGSValidationRuleCardExpirationDate: VGSValidationRuleProtocol {
 
 extension VGSValidationRuleCardExpirationDate: VGSRuleValidator {
   internal func validate(input: String?) -> Bool {
-
         guard let input = input else {
             return false
         }
@@ -75,7 +74,7 @@ extension VGSValidationRuleCardExpirationDate: VGSRuleValidator {
         let todayYY = Calendar(identifier: .gregorian).component(.year, from: Date())
         let todayMM = Calendar(identifier: .gregorian).component(.month, from: Date())
         
-        guard let inputMM = Int(mm), var inputYY = Int(yy) else {
+        guard let inputMM = Int(mm), (1...12).contains(inputMM), var inputYY = Int(yy) else {
             return false
         }
         ///convert input year to long format if needed

--- a/Tests/FrameworkTests/Text Fields Tests/ValidationRulesTest.swift
+++ b/Tests/FrameworkTests/Text Fields Tests/ValidationRulesTest.swift
@@ -140,6 +140,25 @@ class ValidationRulesTest: XCTestCase {
       XCTAssertTrue(textfield.state.validationErrors.count == 1)
       XCTAssertTrue(textfield.state.validationErrors.first == error)
       
+      /// Test  month in valid range
+      textfield.textField.secureText = "1322"
+      XCTAssertTrue(textfield.state.isValid == false)
+      XCTAssertTrue(textfield.state.validationErrors.count == 1)
+      XCTAssertTrue(textfield.state.validationErrors.first == error)
+      
+      textfield.textField.secureText = "0122"
+      XCTAssertTrue(textfield.state.isValid == true)
+      XCTAssertTrue(textfield.state.validationErrors.count == 0)
+      
+      textfield.textField.secureText = "1222"
+      XCTAssertTrue(textfield.state.isValid == true)
+      XCTAssertTrue(textfield.state.validationErrors.count == 0)
+      
+      textfield.textField.secureText = "0022"
+      XCTAssertTrue(textfield.state.isValid == false)
+      XCTAssertTrue(textfield.state.validationErrors.count == 1)
+      XCTAssertTrue(textfield.state.validationErrors.first == error)
+
       config.validationRules = VGSValidationRuleSet(rules: [
         VGSValidationRuleCardExpirationDate(dateFormat: .longYear, error: error)
       ])


### PR DESCRIPTION
## Fixes [iOSSDK-137]

## Description of changes
Throw VGSError on not valid month

## Testing
Unit Tests.
