### PR TITLE
CardScan integration via SPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CardScan",
+        "repositoryURL": "https://github.com/getbouncer/cardscan-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "caadb6c9b2059b3da7879e5c86be5f22a7295865",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,17 @@ let package = Package(
         .library(
             name: "VGSCollectSDK",
             targets: ["VGSCollectSDK"]),
+				.library(
+						name: "VGSCardScanCollector",
+						targets: ["VGSCardScanCollector"]
+			),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+			.package(
+				name: "CardScan",
+				url: "https://github.com/getbouncer/cardscan-ios.git",
+				.revision("caadb6c9b2059b3da7879e5c86be5f22a7295865")
+			),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -29,6 +36,12 @@ let package = Package(
         .testTarget(
             name: "FrameworkTests",
             dependencies: ["VGSCollectSDK"]
-				)
-			]
+				),
+				.target(
+						name: "VGSCardScanCollector",
+						dependencies: ["VGSCollectSDK",
+											.product(name: "CardScan", package: "CardScan")],
+						path: "Sources/VGSCardScanCollector/"
+		 ),
+		]
 )

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Don't forget to import `VGSCardIOCollector` or `VGSCardScanCollector` in files w
 > NOTE: At this time **Carthage** does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built by default. However you can include into your project only submodules that you need.
 
 
-### Swift Package Manager
+### Swift Package Manager (Beta)
 
 The [Swift Package Manager](https://swift.org/package-manager/) is a tool for automating the distribution of Swift code and is integrated into the `swift` compiler.
 Xcode with Swift tools version of 5.3 is required for VGSCollectSDK. Earlier Xcode versions don't support Swift packages with resources.
@@ -91,13 +91,15 @@ xcrun swift -version
 
 > NOTE: In some cases you can have multiple Swift tools versions installed.
 
-Once you have your Swift package set up, add VGSCollectSDK dependency.
 
-```swift
-dependencies: [
-    .package(url: "https://github.com/verygoodsecurity/vgs-collect-ios", .upToNextMajor(from: "1.7.0"))
-]
-```
+Follow the official Apple SPM guide [instructions](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).  
+To use Swift Package Manager, in Xcode add the https://github.com/verygoodsecurity/vgs-collect-ios.git dependency and choose the latest version up to the next major version.
+
+Select `VGSCollectSDK`  package.
+
+Starting with the 1.7.4 release, `VGSCollectSDK` also supports  [CardScan](https://github.com/getbouncer/cardscan-ios) integration via SPM.
+To use **CardScan** add `VGSCollectSDK`, `VGSCardScanCollector` libraries to your target. 
+
 
 ## Usage
 

--- a/Sources/VGSCardScanCollector/VGSCardScanController.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanController.swift
@@ -10,6 +10,9 @@ import Foundation
 #if !COCOAPODS
 import VGSCollectSDK
 #endif
+#if os(iOS)
+import UIKit
+#endif
 
 /// Controller responsible for managing CardScan scanner
 public class VGSCardScanController {

--- a/Sources/VGSCardScanCollector/VGSCardScanControllerDelegate.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanControllerDelegate.swift
@@ -10,6 +10,9 @@ import Foundation
 #if !COCOAPODS
 import VGSCollectSDK
 #endif
+#if os(iOS)
+import UIKit
+#endif
 
 /// Supported scan data fields by CardScan
 @objc

--- a/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
@@ -11,6 +11,9 @@ import CardScan
 #if !COCOAPODS
 import VGSCollectSDK
 #endif
+#if os(iOS)
+import UIKit
+#endif
 
 internal class VGSCardScanHandler: NSObject, VGSScanHandlerProtocol {
     
@@ -19,17 +22,28 @@ internal class VGSCardScanHandler: NSObject, VGSScanHandlerProtocol {
   
     required init(apiKey: String) {
       super.init()
-      ScanViewController.configure(apiKey: apiKey)
+
+			if #available(iOS 11.2, *) {
+				ScanViewController.configure(apiKey: apiKey)
+			} else {
+				print("⚠️ Unsupported iOS version, should be iOS 11.2 or higher.")
+			}
     }
     
     func presentScanVC(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
-        guard let vc = ScanViewController.createViewController(withDelegate: self) else {
-            print("This device is incompatible with CardScan")
-            return
-        }
-        self.view = vc
-        vc.scanDelegate = self
-        viewController.present(vc, animated: true)
+
+			if #available(iOS 11.2, *) {
+				guard let vc = ScanViewController.createViewController(withDelegate: self) else {
+						print("⚠️ This device is incompatible with CardScan.")
+						return
+				}
+				print("ScanViewController.version(): \(ScanViewController.version())")
+				self.view = vc
+				vc.scanDelegate = self
+				viewController.present(vc, animated: true)
+			} else {
+				print("⚠️ Unsupported iOS version, should be iOS 11.2 or higher.")
+			}
     }
     
     func dismissScanVC(animated: Bool, completion: (() -> Void)?) {
@@ -37,11 +51,18 @@ internal class VGSCardScanHandler: NSObject, VGSScanHandlerProtocol {
     }
   
     static func isCompatible() -> Bool {
-      return ScanViewController.isCompatible()
+			if #available(iOS 11.2, *) {
+				return ScanViewController.isCompatible()
+			} else {
+				print("⚠️ Unsupported iOS version, should be iOS 11.2 or higher.")
+				return false
+			}
     }
 }
 
 /// :nodoc:
+
+@available(iOS 11.2, *)
 extension VGSCardScanHandler: ScanDelegate {
   func userDidCancel(_ scanViewController: ScanViewController) {
     VGSAnalyticsClient.shared.trackEvent(.scan, status: .cancel, extraData: [ "scannerType": "Bouncer"])

--- a/Sources/VGSCollectSDK/Core/Analytics/VGSAnalyticsClient.swift
+++ b/Sources/VGSCollectSDK/Core/Analytics/VGSAnalyticsClient.swift
@@ -51,12 +51,19 @@ public class VGSAnalyticsClient {
   internal static let userAgentData: [String: Any] = {
       let version = ProcessInfo.processInfo.operatingSystemVersion
       let osVersion = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
-      return [
-              "platform": UIDevice.current.systemName,
-              "device": UIDevice.current.model,
-              "deviceModel": UIDevice.current.modelIdentifier,
-              "osVersion": osVersion,
-							"dependencyManager": sdkIntegration]
+
+			var defaultUserAgentData = [
+				"platform": UIDevice.current.systemName,
+				"device": UIDevice.current.model,
+				"deviceModel": UIDevice.current.modelIdentifier,
+				"osVersion": osVersion,
+				"dependencyManager": sdkIntegration]
+
+				if let locale = Locale.preferredLanguages.first {
+					defaultUserAgentData["deviceLocale"] = locale
+				}
+
+      return defaultUserAgentData
       }()
 
   /// :nodoc: Track events related to specific VGSCollect instance

--- a/VGSCollectSDK.podspec
+++ b/VGSCollectSDK.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'CardScan' do |cardscan|
     cardscan.source_files  = "Sources/VGSCardScanCollector", "Sources/VGSCardScanCollector/**/*.{swift}"
     cardscan.dependency "VGSCollectSDK/Core"
-    cardscan.dependency "CardScan", "1.0.5048"
+    cardscan.dependency "CardScan", "2.0.7"
   end
   
   spec.subspec 'CardIO' do |cardIO|

--- a/VGSCollectSDK.xcodeproj/project.pbxproj
+++ b/VGSCollectSDK.xcodeproj/project.pbxproj
@@ -1188,7 +1188,7 @@
 				);
 				INFOPLIST_FILE = VGSCardScanCollector/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1220,7 +1220,7 @@
 				);
 				INFOPLIST_FILE = VGSCardScanCollector/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/demoapp/Podfile
+++ b/demoapp/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '10.1'
+platform :ios, '11.2'
 
 target 'demoapp' do
   # Comment the next line if you don't want to use dynamic frameworks


### PR DESCRIPTION
## Fixes [IOSSDK-143]

## Description of changes
-  Support CardScan for SPM.
-  Add warnings for min iOS version.
-  Add checks for min iOS version.
-  Update CardScan to 2.0.7.
-  Update ReadMe.
-  Update PodSpec.
-  Update demo app min iOS version to 11.2.

[IOSSDK-143]: https://verygoodsecurity.atlassian.net/browse/IOSSDK-143