### PR TITLE
Set locale to English for expiration date convertor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Run Tests iOS 13-14
-          command: xcodebuild test -project VGSCollectSDK.xcodeproj -scheme VGSCollectSDK -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.1'
+          command: xcodebuild test -project VGSCollectSDK.xcodeproj -scheme FrameworkTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.1' -testPlan FrameworkTests
   build-and-ui-test-demo-app-ios-14-iphone12:
     macos:
       xcode: "12.1"

--- a/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
+++ b/Sources/VGSCardScanCollector/VGSCardScanHandler.swift
@@ -40,7 +40,7 @@ internal class VGSCardScanHandler: NSObject, VGSScanHandlerProtocol {
 				print("ScanViewController.version(): \(ScanViewController.version())")
 				self.view = vc
 				vc.scanDelegate = self
-				viewController.present(vc, animated: true)
+				viewController.present(vc, animated: true, completion: completion)
 			} else {
 				print("⚠️ Unsupported iOS version, should be iOS 11.2 or higher.")
 			}

--- a/Sources/VGSCollectSDK/Utils/Convertors/ExpDateFormatConvertor.swift
+++ b/Sources/VGSCollectSDK/Utils/Convertors/ExpDateFormatConvertor.swift
@@ -33,7 +33,7 @@ internal class ExpDateFormatConvertor: TextFormatConvertor {
     let inputYear = String(input.suffix(inputFormat.yearCharacters))
     let inputStart = input.dropLast(inputFormat.yearCharacters)
     
-    var dateFormatter = DateFormatter()
+		let dateFormatter = DateFormatter()
     dateFormatter.calendar = Calendar(identifier: .gregorian)
     dateFormatter.dateFormat = inputFormat.dateYearFormat
 		dateFormatter.locale = Locale(identifier: "en_US")

--- a/Sources/VGSCollectSDK/Utils/Convertors/ExpDateFormatConvertor.swift
+++ b/Sources/VGSCollectSDK/Utils/Convertors/ExpDateFormatConvertor.swift
@@ -33,9 +33,10 @@ internal class ExpDateFormatConvertor: TextFormatConvertor {
     let inputYear = String(input.suffix(inputFormat.yearCharacters))
     let inputStart = input.dropLast(inputFormat.yearCharacters)
     
-    let dateFormatter = DateFormatter()
+    var dateFormatter = DateFormatter()
     dateFormatter.calendar = Calendar(identifier: .gregorian)
     dateFormatter.dateFormat = inputFormat.dateYearFormat
+		dateFormatter.locale = Locale(identifier: "en_US")
     
     if let date = dateFormatter.date(from: inputYear) {
       dateFormatter.dateFormat = outputFormat.dateYearFormat

--- a/Tests/FrameworkTests/ConvertorsTests/FrameworkTests.xctestplan
+++ b/Tests/FrameworkTests/ConvertorsTests/FrameworkTests.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "04A09FD5-BB5B-41F2-A2F1-B0C4ADA30E43",
+      "name" : "English",
+      "options" : {
+
+      }
+    },
+    {
+      "id" : "19689B0B-11BE-421B-A1F9-6F66CA2F01B6",
+      "name" : "Arabic",
+      "options" : {
+        "language" : "ar"
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:VGSCollectSDK.xcodeproj",
+        "identifier" : "FD2495502330CB49009024E6",
+        "name" : "FrameworkTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextField.swift
+++ b/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextField.swift
@@ -32,7 +32,7 @@ class ExpDateTextField: VGSCollectBaseTestCase {
         textField.monthPickerFormat = .longSymbols
 
 			  // For Arabic long and short month is the same.
-				let firstLongAr = "يناير"
+				let firstLongAr = "1يناير"
 			  var validLongMonth = "January"
 			  var validShortMonth = "Jan"
 				if Locale.current.languageCode == "ar" {

--- a/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextField.swift
+++ b/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextField.swift
@@ -32,7 +32,7 @@ class ExpDateTextField: VGSCollectBaseTestCase {
         textField.monthPickerFormat = .longSymbols
 
 			  // For Arabic long and short month is the same.
-				let firstLongAr = "1يناير"
+				let firstLongAr = "يناير"
 			  var validLongMonth = "January"
 			  var validShortMonth = "Jan"
 				if Locale.current.languageCode == "ar" {

--- a/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextField.swift
+++ b/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextField.swift
@@ -30,9 +30,18 @@ class ExpDateTextField: VGSCollectBaseTestCase {
     
     func testMonthFormat() {
         textField.monthPickerFormat = .longSymbols
-        XCTAssertTrue(textField.monthsDataSource.first == "January")
+
+			  // For Arabic long and short month is the same.
+				let firstLongAr = "يناير"
+			  var validLongMonth = "January"
+			  var validShortMonth = "Jan"
+				if Locale.current.languageCode == "ar" {
+					validLongMonth = firstLongAr
+					validShortMonth = firstLongAr
+				}
+        XCTAssertTrue(textField.monthsDataSource.first == validLongMonth)
         textField.monthPickerFormat = .shortSymbols
-        XCTAssertTrue(textField.monthsDataSource.first == "Jan")
+        XCTAssertTrue(textField.monthsDataSource.first == validShortMonth)
         textField.monthPickerFormat = .numbers
         XCTAssertTrue(textField.monthsDataSource.last == "12")
     }

--- a/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextFieldTests.swift
+++ b/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/ExpDateTextFieldTests.swift
@@ -86,6 +86,7 @@ class ExpDateTextFieldTests: VGSCollectBaseTestCase {
         /// Test today
         let today = Date()
         let formatter = DateFormatter()
+				formatter.locale = Locale(identifier: "en_US")
 
         formatter.dateFormat = "yy"
         let todayYY = formatter.string(from: today)

--- a/VGSCollectSDK.xcodeproj/project.pbxproj
+++ b/VGSCollectSDK.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		44AF14D22616CCFC0055CD91 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		44AF15042616CF680055CD91 /* VGSCardIODataMapUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardIODataMapUtilsTests.swift; sourceTree = "<group>"; };
 		44C23A7825F7B7EF000EA556 /* VGSFieldNameToJSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSFieldNameToJSONTests.swift; sourceTree = "<group>"; };
+		44F3B861261B6EE500BCB354 /* FrameworkTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FrameworkTests.xctestplan; sourceTree = "<group>"; };
 		44F8F51B25DBD1950052647A /* VGSCollectSatelliteUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCollectSatelliteUtils.swift; sourceTree = "<group>"; };
 		44F8F52325DBE7E40052647A /* VGSCollectSatelliteUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCollectSatelliteUtilsTests.swift; sourceTree = "<group>"; };
 		FD05F9392316CE5A000EAF52 /* Storage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
@@ -459,6 +460,7 @@
 			isa = PBXGroup;
 			children = (
 				322F94D625BAC3E0001CDF12 /* ExpDateConvertorTests.swift */,
+				44F3B861261B6EE500BCB354 /* FrameworkTests.xctestplan */,
 			);
 			path = ConvertorsTests;
 			sourceTree = "<group>";

--- a/VGSCollectSDK.xcodeproj/xcshareddata/xcschemes/FrameworkTests.xcscheme
+++ b/VGSCollectSDK.xcodeproj/xcshareddata/xcschemes/FrameworkTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1140"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -11,6 +11,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/FrameworkTests/ConvertorsTests/FrameworkTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
+++ b/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
@@ -134,20 +134,20 @@ class CardsDataCollectingViewController: UIViewController {
         /// Use `VGSExpDateConfiguration` if you need to convert output date format
         let expDateConfiguration = VGSExpDateConfiguration(collector: vgsCollect, fieldName: "card_expirationDate")
         expDateConfiguration.type = .expDate
-				expDateConfiguration.inputDateFormat = .longYear
+				expDateConfiguration.inputDateFormat = .shortYear
         expDateConfiguration.outputDateFormat = .longYear
       
         /// Default .expDate format is "##/##"
-        expDateConfiguration.formatPattern = "##/####"
+        expDateConfiguration.formatPattern = "##/##"
         
         /// Update validation rules
         expDateConfiguration.validationRules = VGSValidationRuleSet(rules: [
-          VGSValidationRuleCardExpirationDate(dateFormat: .longYear, error: VGSValidationErrorType.expDate.rawValue)
+          VGSValidationRuleCardExpirationDate(dateFormat: .shortYear, error: VGSValidationErrorType.expDate.rawValue)
         ])
 
         expCardDate.configuration = expDateConfiguration
-        expCardDate.placeholder = "MM/YYYY"
-        expCardDate.monthPickerFormat = .longSymbols
+        expCardDate.placeholder = "MM/YY"
+        expCardDate.monthPickerFormat = .shortSymbols
       
         let cvcConfiguration = VGSConfiguration(collector: vgsCollect, fieldName: "card_cvc")
         cvcConfiguration.type = .cvc

--- a/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
+++ b/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
@@ -147,7 +147,7 @@ class CardsDataCollectingViewController: UIViewController {
 
         expCardDate.configuration = expDateConfiguration
         expCardDate.placeholder = "MM/YY"
-        expCardDate.monthPickerFormat = .shortSymbols
+        expCardDate.monthPickerFormat = .longSymbols
       
         let cvcConfiguration = VGSConfiguration(collector: vgsCollect, fieldName: "card_cvc")
         cvcConfiguration.type = .cvc

--- a/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
+++ b/demoapp/demoapp/Use Cases/CardsDataCollectingViewController.swift
@@ -134,6 +134,7 @@ class CardsDataCollectingViewController: UIViewController {
         /// Use `VGSExpDateConfiguration` if you need to convert output date format
         let expDateConfiguration = VGSExpDateConfiguration(collector: vgsCollect, fieldName: "card_expirationDate")
         expDateConfiguration.type = .expDate
+				expDateConfiguration.inputDateFormat = .longYear
         expDateConfiguration.outputDateFormat = .longYear
       
         /// Default .expDate format is "##/##"

--- a/demoapp/demoappUITests/TestCollectCardsDataFlow.swift
+++ b/demoapp/demoappUITests/TestCollectCardsDataFlow.swift
@@ -18,7 +18,7 @@ class TestCollectCardsDataFlow: TestCollectBaseTestCase {
 
       let cardHolderNameField = app.textFields["Cardholder Name"]
       let cardNumberField = app.textFields["4111 1111 1111 1111"]
-      let expDateField = app.textFields["MM/YYYY"]
+      let expDateField = app.textFields["MM/YY"]
       let cvcField = app.secureTextFields["CVC"]
       let consoleLabel = app.staticTexts.matching(identifier: "ConsoleLabelIdentifire")
       let navigationBar = app.navigationBars["Collect Payment Cards"].staticTexts["Collect Payment Cards"]


### PR DESCRIPTION
## Fixes [IOSSDK-192]

## Description of changes
-  Set Locale to static `en_US` to resolve issue with arabic date in JSON.
-  Add test plans for Eng and Arabic.
-  Update some tests for Arabic test plan.
-  Add missing `inputFormat` to demo app.

[IOSSDK-192]: https://verygoodsecurity.atlassian.net/browse/IOSSDK-192