### PR TITLE
Add flat JSON mapping policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run UI Tests on iPhone 12 iOS 14.1
+          name: Run UI Tests on iPhone 12 iOS 14.2
           command: >
             cd demoapp &&
             cd demoapp &&
@@ -33,18 +33,18 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run UI Tests on iPad Air (3rd generation) iOS 13.5
+          name: Run UI Tests on iPad Air (3rd generation) iOS 13.7
           command: >
             cd demoapp &&
             cd demoapp &&
             plutil -insert vaultID -string ${vaultID} UITestsMockedData.plist &&
             cd .. &&
             pod install &&
-            xcrun instruments -w "iPad Air (3rd generation) (13.5) [" || true &&
+            xcrun instruments -w "iPad Air (3rd generation) (13.7) [" || true &&
             xcodebuild test -workspace demoapp.xcworkspace
             -scheme demoappUITests
             -sdk iphonesimulator
-            -destination 'platform=iOS Simulator,name=iPad Air (3rd generation),OS=13.5'
+            -destination 'platform=iOS Simulator,name=iPad Air (3rd generation),OS=13.7'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Run Tests iOS 13-14
-          command: xcodebuild test -project VGSCollectSDK.xcodeproj -scheme FrameworkTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.1' -testPlan FrameworkTests
+          command: xcodebuild test -project VGSCollectSDK.xcodeproj -scheme FrameworkTests -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.2' -testPlan FrameworkTests
   build-and-ui-test-demo-app-ios-14-iphone12:
     macos:
       xcode: "12.1"
@@ -22,11 +22,11 @@ jobs:
             plutil -insert vaultID -string ${vaultID} UITestsMockedData.plist &&
             cd .. &&
             pod install &&
-            xcrun instruments -w "iPhone 12 (14.1) [" || true &&
+            xcrun instruments -w "iPhone 12 (14.2) [" || true &&
             xcodebuild test -workspace demoapp.xcworkspace
             -scheme demoappUITests
             -sdk iphonesimulator
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.1'
+            -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.2'
   build-and-ui-test-demo-app-ios-13-ipad-air-3:
     macos:
       xcode: "12.1"

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect+fieldNameMapping.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect+fieldNameMapping.swift
@@ -18,8 +18,10 @@ internal extension VGSCollect {
 	func mapFieldsToBodyJSON(with mergePolicy: VGSCollectFieldNameMappingPolicy, extraData: JsonData?) -> JsonData {
 
 		switch mergePolicy {
+		case .flatJSON:
+			return mapStoredInputDataForSubmit(with: extraData, isNestedFieldNameJSON: true)
 		case .nestedJSON:
-			return mapStoredInputDataForSubmit(with: extraData)
+			return mapStoredInputDataForSubmit(with: extraData, isNestedFieldNameJSON: true)
 		case .nestedJSONWithArrayMerge:
 			return VGSCollect.mapStoredInputDataForSubmitWithArrays(fields: storage.textFields, mergeArrayPolicy: .merge, extraData: extraData)
 		case .nestedJSONWithArrayOverwrite:

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect+fieldNameMapping.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect+fieldNameMapping.swift
@@ -19,9 +19,9 @@ internal extension VGSCollect {
 
 		switch mergePolicy {
 		case .flatJSON:
-			return mapStoredInputDataForSubmit(with: extraData, isNestedFieldNameJSON: true)
+			return VGSCollect.mapStoredInpuToFlatJSON(with: extraData, from: storage.textFields)
 		case .nestedJSON:
-			return mapStoredInputDataForSubmit(with: extraData, isNestedFieldNameJSON: true)
+			return mapStoredInputDataForSubmit(with: extraData)
 		case .nestedJSONWithArrayMerge:
 			return VGSCollect.mapStoredInputDataForSubmitWithArrays(fields: storage.textFields, mergeArrayPolicy: .merge, extraData: extraData)
 		case .nestedJSONWithArrayOverwrite:

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect+internal.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect+internal.swift
@@ -69,16 +69,11 @@ internal extension VGSCollect {
     }
     
     /// Turns textfields data saved in Storage and extra data in format ready to send
-	func mapStoredInputDataForSubmit(with extraData: [String: Any]? = nil, isNestedFieldNameJSON: Bool) -> [String: Any] {
+	func mapStoredInputDataForSubmit(with extraData: [String: Any]? = nil) -> [String: Any] {
 
-        let textFieldsData: BodyData = mapFieldsDataToBody()
+		   let textFieldsData: BodyData = VGSCollect.mapFieldsDataToBody(from: storage.textFields)
 
-		    var body = textFieldsData
-
-		    // Produce nested JSON for each `.` from field name.
-				if isNestedFieldNameJSON {
-						body = mapInputFieldsDataToDictionary(textFieldsData)
-				}
+		    var body = mapInputFieldsDataToDictionary(textFieldsData)
 
         if let customData = extraData, customData.count != 0 {
            // NOTE: If there are similar keys on same level, body values will override customvalues values for that keys
@@ -88,10 +83,21 @@ internal extension VGSCollect {
         return body
     }
 
+	static func mapStoredInpuToFlatJSON(with extraData: [String: Any]? = nil, from textFields: [VGSTextField]) -> [String: Any] {
+		var body: BodyData = mapFieldsDataToBody(from: textFields)
+
+		 if let customData = extraData, customData.count != 0 {
+				// NOTE: If there are similar keys on same level, body values will override customvalues values for that keys
+				body = deepMerge(customData, body)
+		 }
+
+		 return body
+	}
+
 	  /// Map fields data to body.
 	  /// - Returns: `BodyData` from collect fields.
-		func mapFieldsDataToBody() -> BodyData {
-			let textFieldsData: BodyData = storage.textFields.reduce(into: BodyData()) { (dict, element) in
+	static func mapFieldsDataToBody(from textFields: [VGSTextField]) -> BodyData {
+			let textFieldsData: BodyData = textFields.reduce(into: BodyData()) { (dict, element) in
 				let output = element.getOutputText()
 
 				/// Check if any serialization should be done before data will be send

--- a/Sources/VGSCollectSDK/Utils/Helpers/Mappers/VGSCollectFieldNameMappingPolicy.swift
+++ b/Sources/VGSCollectSDK/Utils/Helpers/Mappers/VGSCollectFieldNameMappingPolicy.swift
@@ -12,6 +12,19 @@ import Foundation
 public enum VGSCollectFieldNameMappingPolicy {
 
 	/**
+		Map fieldName to JSON without applying any transformations.
+		FieldName is used as single key.
+		Example:
+		card_data.number => JSON
+
+			{
+			 "card_data.number" : "4111-1111-1111-1111"
+			}
+
+		*/
+	case flatJSON
+
+	/**
 	Map fieldName to nested JSON.
 	Example:
 	card_data.number => nested JSON
@@ -101,6 +114,8 @@ public enum VGSCollectFieldNameMappingPolicy {
 	/// Name for analytics.
 	internal var analyticsName: String {
 		switch self {
+		case .flatJSON:
+			return "flat_json"
 		case .nestedJSON:
 			return "nested_json"
 		case .nestedJSONWithArrayMerge:

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/DeepMergeTestJSONs/DeepMergeMergeArrayTestJSONs.json
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/DeepMergeTestJSONs/DeepMergeMergeArrayTestJSONs.json
@@ -15,7 +15,7 @@
 								"card_number": "4111-1111-1111-1111",
 								"card_cvc": "111"
 						},
-						"etraData": {
+						"extraData": {
 								"user_name": "Bob",
 								"user_id": "348193"
 						},
@@ -43,7 +43,7 @@
 								"card_number": "4111-1111-1111-1111",
 								"card_cvc": "111"
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 								"card_number": "4111-1111-1111-1111",
 								"card_cvc": "111"
@@ -67,7 +67,7 @@
 										"card_cvc": "111"
 								}
 						},
-						"etraData": {
+						"extraData": {
 							  "data" : {
 									"user_name": "Bob",
 									"user_id": "348193"
@@ -100,7 +100,7 @@
 										"card_cvc": "111"
 								}
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 								"data": {
 										"card_number": "4111-1111-1111-1111",
@@ -123,7 +123,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", "111"]
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 								"data": ["4111-1111-1111-1111", "111"]
 						},
@@ -143,7 +143,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", null, "111"]
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 								"data": ["4111-1111-1111-1111", null, "111"]
 						},
@@ -163,7 +163,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", "111"]
 						},
-						"etraData": {
+						"extraData": {
 								"data": ["333", "20/22"]
 						},
 						"expectedSubmitJSON": {
@@ -185,7 +185,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", "111"]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [{ "user_id": "123" }, { "user_name": "Bob" }]
 						},
 						"expectedSubmitJSON": {
@@ -212,7 +212,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", null, null, null, "111"]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [{ "user_id": "123" }, { "user_name": "Bob" }]
 						},
 						"expectedSubmitJSON": {
@@ -243,7 +243,7 @@
 										{ "cvc": "111" }
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [{ "user_id": "123" }, { "user_name": "Bob" }]
 						},
 						"expectedSubmitJSON": {
@@ -271,7 +271,7 @@
 										{ "cvc": "111" }
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										{ "card_number": "3434-1111-1111-1111" },
 										{ "cvc": "333" }
@@ -306,7 +306,7 @@
 										{ "cvc": "111" }
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": ["3434-1111-1111-1111", "333"]
 						},
 						"expectedSubmitJSON": {
@@ -338,7 +338,7 @@
 										{ "cvc": "111" }
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [["3434-1111-1111-1111"], ["333"]]
 						},
 						"expectedSubmitJSON": {
@@ -377,7 +377,7 @@
 										{ "cvv": "333" }
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										{ "card_number": "3434-1111-1111-1111" },
 										{ "cvc": "5555" }
@@ -424,7 +424,7 @@
 										{ "cvv": "333" }
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										{ "card_number": "3333-3333-3333-3333" },
 										{ "cvc": "5555" },
@@ -462,7 +462,7 @@
 										"4111-1111-1111-1111"
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										{ "cvc": "333" }
 								]
@@ -489,7 +489,7 @@
 										"4111-1111-1111-1111"
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										{ "cvc": "333" },
 										null
@@ -520,7 +520,7 @@
 										"4111-1111-1111-1111"
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										null,
 										{ "cvc": "333" },
@@ -562,7 +562,7 @@
 										"22"
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 										"1",
 										null,
@@ -599,7 +599,7 @@
 
 								]
 						},
-						"etraData": {
+						"extraData": {
 								"data": [
 									"1"
 								]
@@ -632,7 +632,7 @@
 
 								] }
 						},
-						"etraData": {
+						"extraData": {
 							"card_date": {
 									"personal_data": [
 										"1",
@@ -675,7 +675,7 @@
 										}
 								]
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 							"data": [
 									null,

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/FlatJSONs/FlatPolicyTestJSONs.json
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/FlatJSONs/FlatPolicyTestJSONs.json
@@ -15,7 +15,7 @@
 								"card_number": "4111-1111-1111-1111",
 								"card_cvc": "111"
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 								"card_number": "4111-1111-1111-1111",
 								"card_cvc": "111"
@@ -37,7 +37,7 @@
 										"data.card_number": "4111-1111-1111-1111",
 										"data.card_cvc": "111"
 						},
-						"etraData": {
+						"extraData": {
 								"data" : {
 									"user_name": "Bob",
 									"user_id": "348193"
@@ -68,7 +68,7 @@
 							"data.[0]card_number": "4111-1111-1111-1111",
 							"data.[1]card_cvc": "111"
 						},
-						"etraData": {
+						"extraData": {
 								"data" : {
 									"user_name": "Bob",
 									"user_id": "348193"

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/FlatJSONs/FlatPolicyTestJSONs.json
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/FlatJSONs/FlatPolicyTestJSONs.json
@@ -1,0 +1,89 @@
+{
+		"test_data": [
+				{
+						"fieldsData": [
+								{
+										"fieldName": "card_number",
+										"fieldValue": "4111-1111-1111-1111"
+								},
+								{
+										"fieldName": "card_cvc",
+										"fieldValue": "111"
+								}
+						],
+						"expectedCollectJSON": {
+								"card_number": "4111-1111-1111-1111",
+								"card_cvc": "111"
+						},
+						"etraData": null,
+						"expectedSubmitJSON": {
+								"card_number": "4111-1111-1111-1111",
+								"card_cvc": "111"
+						},
+						"comment": "Fieldname format without dot notation. No extra data."
+				},
+				{
+						"fieldsData": [
+								{
+										"fieldName": "data.card_number",
+										"fieldValue": "4111-1111-1111-1111"
+								},
+								{
+										"fieldName": "data.card_cvc",
+										"fieldValue": "111"
+								}
+						],
+						"expectedCollectJSON": {
+										"data.card_number": "4111-1111-1111-1111",
+										"data.card_cvc": "111"
+						},
+						"etraData": {
+								"data" : {
+									"user_name": "Bob",
+									"user_id": "348193"
+								}
+						},
+						"expectedSubmitJSON": {
+							"data.card_number": "4111-1111-1111-1111",
+							"data.card_cvc": "111",
+								"data": {
+										"user_name": "Bob",
+										"user_id": "348193"
+								}
+						},
+						"comment": "Fieldname format with key-dot notation. Extra data JSON. No nested JSON levels."
+				},
+				{
+						"fieldsData": [
+								{
+										"fieldName": "data.[0]card_number",
+										"fieldValue": "4111-1111-1111-1111"
+								},
+								{
+										"fieldName": "data.[1]card_cvc",
+										"fieldValue": "111"
+								}
+						],
+						"expectedCollectJSON": {
+							"data.[0]card_number": "4111-1111-1111-1111",
+							"data.[1]card_cvc": "111"
+						},
+						"etraData": {
+								"data" : {
+									"user_name": "Bob",
+									"user_id": "348193"
+								}
+						},
+						"expectedSubmitJSON": {
+							"data.[0]card_number": "4111-1111-1111-1111",
+							"data.[1]card_cvc": "111",
+								"data": {
+										"user_name": "Bob",
+										"user_id": "348193"
+								}
+						},
+						"comment": "Fieldname format with key-dot notation and array. Extra data JSON. No nested levels for array."
+				},
+		]
+}
+

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/OverwriteArraysTestJSONs/OverwriteArraysTestJSONs.json
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/TestJSONs/OverwriteArraysTestJSONs/OverwriteArraysTestJSONs.json
@@ -14,7 +14,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", "111"]
 						},
-						"etraData": {
+						"extraData": {
 								"data": ["333", "20/22"]
 						},
 						"expectedSubmitJSON": {
@@ -40,7 +40,7 @@
 						"expectedCollectJSON": {
 								"data": ["4111-1111-1111-1111", "111", null, "10/22"]
 						},
-						"etraData": {
+						"extraData": {
 								"data": ["333", "20/22"]
 						},
 						"expectedSubmitJSON": {
@@ -62,7 +62,7 @@
 						"expectedCollectJSON": {
 								"data": [{ "number": "4111-1111-1111-1111" }, { "cvc": "111" }]
 						},
-						"etraData": {
+						"extraData": {
 								"data": ["333", "20/22"]
 						},
 						"expectedSubmitJSON": {
@@ -87,7 +87,7 @@
 								}
 
 						},
-						"etraData": null,
+						"extraData": null,
 						"expectedSubmitJSON": {
 							"data": {
 								"" : ["4111-1111-1111-1111", "111"]

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/VGSDeepMergeUtilsTests.swift
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/VGSDeepMergeUtilsTests.swift
@@ -56,7 +56,7 @@ class VGSDeepMergeUtilsTests: XCTestCase {
 			self.expectedCollectJSON = expectedCollectJSON
 			self.expectedSubmitJSON = submitJSON
 
-			self.extraData = json["etraData"] as? JsonData ?? nil
+			self.extraData = json["extraData"] as? JsonData ?? nil
 			self.comment = json["comment"] as? String ?? nil
 		}
 	}

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/VGSFieldNameToJSONTests.swift
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/VGSFieldNameToJSONTests.swift
@@ -54,8 +54,12 @@ class VGSFieldNameToJSONTests: XCTestCase {
 }
 
 class VGSFieldNameMapperTestDataProvider {
-	static func provideTestDataForVGSFieldNameToJSON() -> [VGSFieldNameToJSONTests.VGSFieldNameTestData] {
-		guard let rootTestJSON = JsonData(jsonFileName: "VGSFieldNameToJSONTestData"), let testDataJSONArray = rootTestJSON["test_data"] as? [JsonData] else {
+	static func provideTestDataForVGSFieldNameToJSON() -> [VGSFieldNameToJSONTests.VGSFieldNameTestData]  {
+		return provideFieldNameTestData(for: "VGSFieldNameToJSONTestData")
+	}
+
+	static func provideFieldNameTestData(for fileName: String) -> [VGSFieldNameToJSONTests.VGSFieldNameTestData]  {
+		guard let rootTestJSON = JsonData(jsonFileName: fileName), let testDataJSONArray = rootTestJSON["test_data"] as? [JsonData] else {
 			XCTFail("cannot build data for file VGSFieldNameToJSONTestData")
 			return []
 		}
@@ -79,6 +83,10 @@ class VGSFieldNameMapperTestDataProvider {
 
 	static func provideTestDataForOverwriteArrays() -> [VGSDeepMergeUtilsTests.TestJSONData] {
 		return provideTestData(for: "OverwriteArraysTestJSONs")
+	}
+
+	static func provideTestDataForFlatJSON() -> [VGSDeepMergeUtilsTests.TestJSONData] {
+		return provideTestData(for: "FlatPolicyTestJSONs")
 	}
 
 	static func provideTestData(for fileName: String) -> [VGSDeepMergeUtilsTests.TestJSONData] {

--- a/Tests/FrameworkTests/DeepMergeUtils Tests/VGSFlatJSONStructMappingTests.swift
+++ b/Tests/FrameworkTests/DeepMergeUtils Tests/VGSFlatJSONStructMappingTests.swift
@@ -1,0 +1,41 @@
+//
+//  VGSFlatJSONStructMappingTests.swift
+//  FrameworkTests
+//
+
+import Foundation
+import XCTest
+@testable import VGSCollectSDK
+
+class VGSFlatJSONStructMappingTests: XCTestCase {
+
+	/// Test flat JSON mapping.
+	func testFlatJSONMapping() {
+		let testData = VGSFieldNameMapperTestDataProvider.provideTestDataForFlatJSON()
+
+		for index in 0..<testData.count {
+			let item = testData[index]
+			let fieldData = item.fieldsData
+			let expectedCollectJSON = item.expectedCollectJSON
+			let extraData = item.extraData
+			let expectedSubmitJSON = item.expectedSubmitJSON
+			let comment = item.comment ?? ""
+
+			var textFields = [VGSTextField]()
+
+			for fieldItem in fieldData {
+				let field = VGSTextField()
+				field.fieldName = fieldItem.fieldName
+				field.textField.secureText = fieldItem.value
+
+				textFields.append(field)
+			}
+
+			let actualJSONToSubmit: JsonData = VGSCollect.mapStoredInpuToFlatJSON(with: extraData, from: textFields)
+
+			let debugDeepMergeOutput = "index: \(index). \nFielsdData *\(fieldData) \nExtra data: \(extraData) \nshould produce \(expectedSubmitJSON), \n\ncomment: \(comment)* \n\nActual result: \(actualJSONToSubmit)"
+
+			XCTAssertTrue(actualJSONToSubmit == expectedSubmitJSON, debugDeepMergeOutput)
+		}
+	}
+}

--- a/VGSCollectSDK.xcodeproj/project.pbxproj
+++ b/VGSCollectSDK.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		44AF14D32616CCFC0055CD91 /* VGSCardIOCollector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 326FFAF224F904430024A4F9 /* VGSCardIOCollector.framework */; platformFilter = ios; };
 		44AF15052616CF680055CD91 /* VGSCardIODataMapUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44AF15042616CF680055CD91 /* VGSCardIODataMapUtilsTests.swift */; };
 		44C23A7925F7B7EF000EA556 /* VGSFieldNameToJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C23A7825F7B7EF000EA556 /* VGSFieldNameToJSONTests.swift */; };
+		44D520AE2672218A005AB588 /* VGSFlatJSONStructMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D520AD2672218A005AB588 /* VGSFlatJSONStructMappingTests.swift */; };
+		44D520B0267221D7005AB588 /* FlatPolicyTestJSONs.json in Resources */ = {isa = PBXBuildFile; fileRef = 44D520AF267221D7005AB588 /* FlatPolicyTestJSONs.json */; };
 		44F8F51C25DBD1950052647A /* VGSCollectSatelliteUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8F51B25DBD1950052647A /* VGSCollectSatelliteUtils.swift */; };
 		44F8F52F25DBE8770052647A /* VGSCollectSatelliteUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F8F52325DBE7E40052647A /* VGSCollectSatelliteUtilsTests.swift */; };
 		FD05F9472316CE5A000EAF52 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD05F9392316CE5A000EAF52 /* Storage.swift */; };
@@ -307,6 +309,8 @@
 		44AF14D22616CCFC0055CD91 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		44AF15042616CF680055CD91 /* VGSCardIODataMapUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCardIODataMapUtilsTests.swift; sourceTree = "<group>"; };
 		44C23A7825F7B7EF000EA556 /* VGSFieldNameToJSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSFieldNameToJSONTests.swift; sourceTree = "<group>"; };
+		44D520AD2672218A005AB588 /* VGSFlatJSONStructMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSFlatJSONStructMappingTests.swift; sourceTree = "<group>"; };
+		44D520AF267221D7005AB588 /* FlatPolicyTestJSONs.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = FlatPolicyTestJSONs.json; sourceTree = "<group>"; };
 		44F3B861261B6EE500BCB354 /* FrameworkTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FrameworkTests.xctestplan; sourceTree = "<group>"; };
 		44F8F51B25DBD1950052647A /* VGSCollectSatelliteUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCollectSatelliteUtils.swift; sourceTree = "<group>"; };
 		44F8F52325DBE7E40052647A /* VGSCollectSatelliteUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSCollectSatelliteUtilsTests.swift; sourceTree = "<group>"; };
@@ -685,6 +689,7 @@
 		44447F8625F7662A00D4CE68 /* TestJSONs */ = {
 			isa = PBXGroup;
 			children = (
+				44D520AA2672205E005AB588 /* FlatJSONs */,
 				4430E19A2600B8D6006B2EF3 /* OverwriteArraysTestJSONs */,
 				44792A7725FDE68D006A04B8 /* DeepMergeTestJSONs */,
 				44447F8725F7663400D4CE68 /* DotNotationJSONs */,
@@ -723,6 +728,7 @@
 				449C89E825F0AFF400BE009F /* VGSDeepMergeUtilsTests.swift */,
 				44447F7625F74CCC00D4CE68 /* VGSFieldNameMapUtilsTests.swift */,
 				44C23A7825F7B7EF000EA556 /* VGSFieldNameToJSONTests.swift */,
+				44D520AD2672218A005AB588 /* VGSFlatJSONStructMappingTests.swift */,
 			);
 			path = "DeepMergeUtils Tests";
 			sourceTree = "<group>";
@@ -781,6 +787,14 @@
 				44AF15042616CF680055CD91 /* VGSCardIODataMapUtilsTests.swift */,
 			);
 			path = CardIOMapExpirationDateTests;
+			sourceTree = "<group>";
+		};
+		44D520AA2672205E005AB588 /* FlatJSONs */ = {
+			isa = PBXGroup;
+			children = (
+				44D520AF267221D7005AB588 /* FlatPolicyTestJSONs.json */,
+			);
+			path = FlatJSONs;
 			sourceTree = "<group>";
 		};
 		44F8F51A25DBD1860052647A /* SatelliteUtils */ = {
@@ -1257,6 +1271,7 @@
 				44792A7925FDE6AE006A04B8 /* DeepMergeMergeArrayTestJSONs.json in Resources */,
 				328D7C19261352CF00E0917F /* VGSExpDateSerialization_MapWithArrayMerge.json in Resources */,
 				3215C5072611B87400F21259 /* VGSExpDateSerialization_DefaultConfig.json in Resources */,
+				44D520B0267221D7005AB588 /* FlatPolicyTestJSONs.json in Resources */,
 				3259B3DB2632AF7B008EECE0 /* VGSExpDateSerialization_CustomExpDateOutputConfig.json in Resources */,
 				44447F8925F7667000D4CE68 /* VGSFieldNameToJSONTestData.json in Resources */,
 				328D7C18261352CF00E0917F /* VGSExpDateSerialization_MapWithArrayOverwrite.json in Resources */,
@@ -1486,6 +1501,7 @@
 				FDF696E3234643F300063507 /* LuhnTests.swift in Sources */,
 				44C23A7925F7B7EF000EA556 /* VGSFieldNameToJSONTests.swift in Sources */,
 				3270D3F1248155B200004E3B /* SSNTextFieldTests.swift in Sources */,
+				44D520AE2672218A005AB588 /* VGSFlatJSONStructMappingTests.swift in Sources */,
 				FDF696E123463ACB00063507 /* TextFielsStyleUI.swift in Sources */,
 				3213005B241FA0BE0062FEF0 /* VGSCollectTest+Validation.swift in Sources */,
 				32059CD42417EACC003E9481 /* UtilsTest.swift in Sources */,


### PR DESCRIPTION
## Fixes [IOSSDK-232]

## Description of changes
- add `flatJSON` mapping policy;
- add unit tests;
- add analytics key;
- add separate methods for flat mapping policy to keep default logic.


[IOSSDK-232]: https://verygoodsecurity.atlassian.net/browse/IOSSDK-232