### PR TITLE
Fix SPM build which fails intermittently

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,56 +13,57 @@ let package = Package(
         .library(
             name: "VGSCollectSDK",
             targets: ["VGSCollectSDK", "VGSPaymentCards"]),
-				.library(
-						name: "VGSCardScanCollector",
-						targets: ["VGSCardScanCollector"]
-			),
-			.library(
-				name: "VGSCardIOCollector",
-				targets: ["VGSCardIOCollector"])
+        .library(
+            name: "VGSCardScanCollector",
+            targets: ["VGSCardScanCollector"]
+        ),
+        .library(
+            name: "VGSCardIOCollector",
+            targets: ["VGSCardIOCollector"])
     ],
     dependencies: [
-			.package(
-				name: "CardScan",
-				url: "https://github.com/getbouncer/cardscan-ios.git",
-				.exact("2.0.9")
-			),
-			.package(
-						name: "CardIOSDK",
-						url: "https://github.com/verygoodsecurity/CardIOSDK-iOS.git",
-						.exact("5.5.5")
-			)
+        .package(
+            name: "CardScan",
+            url: "https://github.com/getbouncer/cardscan-ios.git",
+            .exact("2.0.9")
+        ),
+        .package(
+            name: "CardIOSDK",
+            url: "https://github.com/verygoodsecurity/CardIOSDK-iOS.git",
+            .exact("5.5.5")
+        )
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "VGSCollectSDK",
-  					exclude: [
-              "Info.plist",
-							"VGSCollectSDK.h"
-	 				]),
+            dependencies: ["VGSPaymentCards"],
+            exclude: [
+                "Info.plist",
+                "VGSCollectSDK.h"
+            ]),
         .target(name: "VGSPaymentCards",
                 path: "Sources/VGSPaymentCards/",
                 exclude:  [
-									"Info.plist",
-                  "VGSPaymentCards.h"
+                    "Info.plist",
+                    "VGSPaymentCards.h"
                 ]
         ),
         .testTarget(
             name: "FrameworkTests",
             dependencies: ["VGSCollectSDK"]
-				),
-				.target(
-						name: "VGSCardScanCollector",
-						dependencies: ["VGSCollectSDK",
-											.product(name: "CardScan", package: "CardScan")],
-						path: "Sources/VGSCardScanCollector/"
-		 ),
-			.target(
-				name: "VGSCardIOCollector",
-				dependencies: ["VGSCollectSDK",
-											 .product(name: "CardIOSDK", package: "CardIOSDK")],
-				path: "Sources/VGSCardIOCollector/")
-		]
+        ),
+        .target(
+            name: "VGSCardScanCollector",
+            dependencies: ["VGSCollectSDK",
+                           .product(name: "CardScan", package: "CardScan")],
+            path: "Sources/VGSCardScanCollector/"
+        ),
+        .target(
+            name: "VGSCardIOCollector",
+            dependencies: ["VGSCollectSDK",
+                           .product(name: "CardIOSDK", package: "CardIOSDK")],
+            path: "Sources/VGSCardIOCollector/")
+    ]
 )

--- a/Tests/FrameworkTests/Test Helpers/JSON Helpers/JSONData+Extensions.swift
+++ b/Tests/FrameworkTests/Test Helpers/JSON Helpers/JSONData+Extensions.swift
@@ -17,9 +17,10 @@ internal extension JsonData {
 			print("JSON file \(jsonFileName).json not found or is invalid")
 		}
 
-		let bundle = Bundle(for: type(of: VGSCollectTestBundleHelper()))
 		#if SWIFT_PACKAGE
-			bundle = Bundle.module
+			let bundle = Bundle.module
+        #else
+            let bundle = Bundle(for: type(of: VGSCollectTestBundleHelper()))
 		#endif
 
 		if let path = bundle.path(forResource: jsonFileName, ofType: "json") {


### PR DESCRIPTION
## Description of changes
In a client app consuming VGSCollectSDK, we're seeing consistent build failures from a clean state with VGSCollectSDK. After a bit of tracking it down, it appears that `VGSCollectSDK` depends on `VGSPaymentCards`, but isn't implicitly set as a dependency in the Package.swift target definition. This PR fixes that.

- Also had Xcode re-indent the Package.swift, which had non-standard and IMO confusing indentation, possibly a contributing factor here
- Fixed a separate build issue in `Tests/FrameworkTests/Test Helpers/JSON Helpers/JSONData+Extensions.swift` -- easily reproducible if you opened the `Package.swift` instead of the Xcode project itself.
