### PR TITLE
Fix SPM warnings for Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,11 +44,7 @@ let package = Package(
 							"VGSCollectSDK.h"
 	 				]),
         .target(name: "VGSPaymentCards",
-                path: "Sources/VGSPaymentCards/",
-                exclude:  [
-									"Info.plist",
-                  "VGSPaymentCards.h"
-                ]
+                path: "Sources/VGSPaymentCards/"
         ),
         .testTarget(
             name: "FrameworkTests",


### PR DESCRIPTION
## Fixes https://github.com/verygoodsecurity/vgs-collect-ios/issues/289

## Description of changes
Remove no-longer-correct excludes from Package.swift

## Value being added
Fixes warnings for clients that use Swift Package Manager and Xcode 13

## Testing
Manually verify warnings go away.
