### PR TITLE
Add maxInputLength option.

### DIFF
--- a/Sources/VGSCollectSDK/Core/VGSConfiguration.swift
+++ b/Sources/VGSCollectSDK/Core/VGSConfiguration.swift
@@ -58,7 +58,11 @@ public class VGSConfiguration: VGSTextFieldConfigurationProtocol {
     public var isRequiredValidOnly: Bool = false
     
     /// Input data visual format pattern. If not applied, will be  set by default depending on field `type`.
-    public var formatPattern: String?
+		public var formatPattern: String? {
+			didSet {
+				logWarningForFormatPatternIfNeeded()
+			}
+		}
     
     /// String, used to replace not default `VGSConfiguration.formatPattern` characters in input text on send request.
     public var divider: String?
@@ -76,7 +80,20 @@ public class VGSConfiguration: VGSTextFieldConfigurationProtocol {
     public var validationRules: VGSValidationRuleSet?
 
 	  /// Max input length. **IMPORTANT!** Can conflict with `.formatPattern` attribute.
-		public var maxInputLength: Int?
+		public var maxInputLength: Int? {
+			didSet {
+				logWarningForFormatPatternIfNeeded()
+			}
+		}
+
+	  /// Logs warning when both `.formatPattern` and `.maxInputLength` are used.
+		internal func logWarningForFormatPatternIfNeeded() {
+			if !formatPattern.isNilOrEmpty && maxInputLength != nil {
+				let message = "Format pattern (\(formatPattern)) and maxInputLength (\(maxInputLength)) can conflict when both are in use!"
+				let event = VGSLogEvent(level: .warning, text: message, severityLevel: .warning)
+				VGSCollectLogger.shared.forwardLogEvent(event)
+			}
+		}
            
     // MARK: - Initialization
     

--- a/Sources/VGSCollectSDK/Core/VGSConfiguration.swift
+++ b/Sources/VGSCollectSDK/Core/VGSConfiguration.swift
@@ -74,6 +74,9 @@ public class VGSConfiguration: VGSTextFieldConfigurationProtocol {
   
     /// Validation rules for field input. Defines `State.isValide` result.
     public var validationRules: VGSValidationRuleSet?
+
+	  /// Max input length. **IMPORTANT!** Can conflict with `.formatPattern` attribute.
+		public var maxInputLength: Int?
            
     // MARK: - Initialization
     

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField+security.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField+security.swift
@@ -18,6 +18,7 @@ extension MaskedTextField {
     override public var delegate: UITextFieldDelegate? {
         get { return nil }
         set {
+					// Use only internal masked text field as a delegate.
 					if let value = newValue as? MaskedTextField {
 						super.delegate = value
 					}

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField+security.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField+security.swift
@@ -17,7 +17,11 @@ extension MaskedTextField {
 	  /// :nodoc: Replace native textfield delgate with custom.
     override public var delegate: UITextFieldDelegate? {
         get { return nil }
-        set {}
+        set {
+					if let value = newValue as? MaskedTextField {
+						super.delegate = value
+					}
+				}
     }
     
     func addSomeTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
@@ -10,6 +10,11 @@
 import UIKit
 #endif
 
+internal protocol MaskedTextFieldDelegate: AnyObject {
+	func maskedTextField(_ maskedTextField: UITextField, shouldChangeCharactersInRange range: NSRange,
+												 replacementString string: String) -> Bool
+}
+
 /// :nodoc: Internal wrapper for `UITextField`.
 internal class MaskedTextField: UITextField {
     enum MaskedTextReplacementChar: String, CaseIterable {
@@ -19,6 +24,8 @@ internal class MaskedTextField: UITextField {
         case upperCaseLetter = "A"
         case digits = "#"
     }
+
+		internal weak var customDelegate: MaskedTextFieldDelegate?
 
     /**
      Var that holds the format pattern that you wish to apply
@@ -264,6 +271,17 @@ internal class MaskedTextField: UITextField {
             }
         }
     }
+}
+
+extension MaskedTextField: UITextFieldDelegate {
+	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+								 replacementString string: String) -> Bool {
+		guard let customTextFieldDelegate = customDelegate else {
+			return false
+		}
+
+		return customTextFieldDelegate.maskedTextField(textField, shouldChangeCharactersInRange: range, replacementString: string)
+	}
 }
 
 extension MaskedTextField {

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
@@ -26,6 +26,7 @@ internal class MaskedTextField: UITextField {
         case digits = "#"
     }
 
+	  /// Internal delegate that acts as a proxy of `UITextFieldDelegate`.
 		internal weak var customDelegate: MaskedTextFieldDelegate?
 
     /**
@@ -280,7 +281,7 @@ extension MaskedTextField: UITextFieldDelegate {
 	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange,
 								 replacementString string: String) -> Bool {
 		guard let customTextFieldDelegate = customDelegate else {
-			return false
+			return true
 		}
 
 		return customTextFieldDelegate.maskedTextField(textField, shouldChangeCharactersInRange: range, replacementString: string)

--- a/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/Mask/MaskedTextField.swift
@@ -10,6 +10,7 @@
 import UIKit
 #endif
 
+/// Defines interface for masked text field delegate.
 internal protocol MaskedTextFieldDelegate: AnyObject {
 	func maskedTextField(_ maskedTextField: UITextField, shouldChangeCharactersInRange range: NSRange,
 												 replacementString string: String) -> Bool
@@ -272,6 +273,8 @@ internal class MaskedTextField: UITextField {
         }
     }
 }
+
+// MARK: - UITextFieldDelegate
 
 extension MaskedTextField: UITextFieldDelegate {
 	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange,

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
@@ -119,13 +119,15 @@ public class VGSTextField: UIView {
     /// - Note: This will not change `State.isDirty` attribute.
     /// - Discussion: probably you should want to set field configuration before setting default value, so the input format will be update as required.
     public func setDefaultText(_ text: String?) {
-      updateTextFieldInput(text)
+			let trimmedText = trimTextIfNeeded(text)
+			updateTextFieldInput(trimmedText)
     }
   
     /// :nodoc: Set textfield text.
     public func setText(_ text: String?) {
-      isDirty = true
-      updateTextFieldInput(text)
+			isDirty = true
+			let trimmedText = trimTextIfNeeded(text)
+			updateTextFieldInput(trimmedText)
     }
 
     /// Removes input from field.
@@ -337,6 +339,18 @@ internal extension VGSTextField {
     textFieldValueChanged()
     delegate?.vgsTextFieldDidChange?(self)
   }
+
+	/// Returns trimmed text if `.maxInputLength` is set.
+	/// - Parameter text: `String?` object, new text to set.
+	/// - Returns: `String?` object, trimmed text or initial text if `.maxInputLength` not set.
+	func trimTextIfNeeded(_ text: String?) -> String? {
+		guard let maxInputLength = configuration?.maxInputLength, let newText = text else {
+			return text
+		}
+
+		let trimmedText = String(newText.prefix(maxInputLength))
+		return trimmedText
+	}
 }
 
 // MARK: - MaskedTextFieldDelegate

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
@@ -79,6 +79,9 @@ public class VGSTextField: UIView {
         textField.autocorrectionType = autocorrectionType
       }
     }
+
+	  /// Defines max input length.
+		public var maxLength: Int?
   
     // MARK: - Functional Attributes
     
@@ -255,7 +258,9 @@ internal extension VGSTextField {
     @objc
     func addTextFieldObservers() {
       //delegates
-      textField.addSomeTarget(self, action: #selector(textFieldDidBeginEditing), for: .editingDidBegin)
+			textField.delegate = textField
+			textField.customDelegate = self
+			textField.addSomeTarget(self, action: #selector(textFieldDidBeginEditing), for: .editingDidBegin)
       //Note: .allEditingEvents doesn't work proparly when set text programatically. Use setText instead!
       textField.addSomeTarget(self, action: #selector(textFieldDidEndEditing), for: .editingDidEnd)
       textField.addSomeTarget(self, action: #selector(textFieldDidEndEditingOnExit), for: .editingDidEndOnExit)
@@ -335,6 +340,16 @@ internal extension VGSTextField {
     textFieldValueChanged()
     delegate?.vgsTextFieldDidChange?(self)
   }
+}
+
+extension VGSTextField: MaskedTextFieldDelegate {
+	func maskedTextField(_ maskedTextField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+		guard let currentMaxLength = maxLength else {return true}
+
+		let currentString: NSString = self.textField.secureText as! NSString
+			 let newString: NSString = currentString.replacingCharacters(in: range, with: string) as NSString
+			return newString.length <= currentMaxLength
+	}
 }
 
 // MARK: - Main style for text field

--- a/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
+++ b/Sources/VGSCollectSDK/UIElements/Text Field/VGSTextField.swift
@@ -79,9 +79,6 @@ public class VGSTextField: UIView {
         textField.autocorrectionType = autocorrectionType
       }
     }
-
-	  /// Defines max input length.
-		public var maxLength: Int?
   
     // MARK: - Functional Attributes
     
@@ -342,13 +339,14 @@ internal extension VGSTextField {
   }
 }
 
+// MARK: - MaskedTextFieldDelegate
+
 extension VGSTextField: MaskedTextFieldDelegate {
 	func maskedTextField(_ maskedTextField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
-		guard let currentMaxLength = maxLength else {return true}
+		guard let maxInputLength = configuration?.maxInputLength, let currentString: NSString = textField.secureText as? NSString else {return true}
 
-		let currentString: NSString = self.textField.secureText as! NSString
-			 let newString: NSString = currentString.replacingCharacters(in: range, with: string) as NSString
-			return newString.length <= currentMaxLength
+		let newString: NSString = currentString.replacingCharacters(in: range, with: string) as NSString
+		return newString.length <= maxInputLength
 	}
 }
 

--- a/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/TextFieldMaxInputLengthTests.swift
+++ b/Tests/FrameworkTests/Satellite Tests/Text Fields Tests/TextFieldMaxInputLengthTests.swift
@@ -1,0 +1,111 @@
+//
+//  TextFieldMaxInputLengthTests.swift
+//  FrameworkTests
+
+import Foundation
+import XCTest
+@testable import VGSCollectSDK
+
+/// Tests for max input length.
+class TextFieldMaxInputLengthTests: VGSCollectBaseTestCase {
+
+	  /// Collect instance.
+		var collector: VGSCollect!
+
+	  /// Configuration instance.
+		var configuration: VGSConfiguration!
+
+	  /// VGS text field.
+		var textfield: VGSTextField!
+
+	  /// Default setup.
+		override func setUp() {
+				super.setUp()
+				collector = VGSCollect(id: "vaultid")
+				configuration = VGSConfiguration.init(collector: collector, fieldName: "test1")
+				textfield = VGSTextField()
+				textfield.configuration = configuration
+		}
+
+		/// Default tear down.
+		override func tearDown() {
+				collector  = nil
+				configuration = nil
+				textfield = nil
+		}
+
+	  /// Test set default text with max input length.
+		func testSetDefaultTextWithMaxLength() {
+			configuration.type = .none
+			configuration.maxInputLength = 3
+			textfield.configuration = configuration
+			textfield.setDefaultText("Joe Doe")
+			XCTAssertTrue(textfield.textField.secureText == "Joe")
+			XCTAssertTrue(textfield.state.inputLength == 3)
+			XCTAssertTrue(textfield.state.isDirty == false)
+			XCTAssertTrue(textfield.state.isEmpty == false)
+			XCTAssertTrue(textfield.state.isValid == true)
+
+			// Test set nil.
+			textfield.setDefaultText(nil)
+			XCTAssertTrue(textfield.textField.secureText == "")
+
+			// Disable max input length.
+			configuration.maxInputLength = nil
+			textfield.setDefaultText("Joe Doe")
+			XCTAssertTrue(textfield.textField.secureText == "Joe Doe")
+			XCTAssertTrue(textfield.state.inputLength == 7)
+			XCTAssertTrue(textfield.state.isDirty == false)
+			XCTAssertTrue(textfield.state.isEmpty == false)
+			XCTAssertTrue(textfield.state.isValid == true)
+		}
+
+		/// Test set text with max input length.
+		func testSetTextWithMaxLength() {
+			configuration.type = .none
+			configuration.maxInputLength = 3
+			textfield.configuration = configuration
+			textfield.setText("Joe Doe")
+			XCTAssertTrue(textfield.textField.secureText == "Joe")
+			XCTAssertTrue(textfield.state.inputLength == 3)
+			XCTAssertTrue(textfield.state.isDirty == true)
+			XCTAssertTrue(textfield.state.isEmpty == false)
+			XCTAssertTrue(textfield.state.isValid == true)
+
+			// Test set nil.
+			textfield.setText(nil)
+			XCTAssertTrue(textfield.textField.secureText == "")
+
+      // Disable max input length.
+			configuration.maxInputLength = nil
+			textfield.setText("Joe Doe")
+			XCTAssertTrue(textfield.textField.secureText == "Joe Doe")
+			XCTAssertTrue(textfield.state.inputLength == 7)
+			XCTAssertTrue(textfield.state.isDirty == true)
+			XCTAssertTrue(textfield.state.isEmpty == false)
+			XCTAssertTrue(textfield.state.isValid == true)
+	}
+
+	/// Test clean text with max input length.
+	func testCleanTextWithMaxInputLength() {
+			configuration.type = .none
+			configuration.maxInputLength = 3
+			textfield.configuration = configuration
+			textfield.setDefaultText("Joe")
+			textfield.cleanText()
+			XCTAssertTrue(textfield.textField.secureText == "")
+			XCTAssertTrue(textfield.state.inputLength == 0)
+			XCTAssertTrue(textfield.state.isDirty == false)
+			XCTAssertTrue(textfield.state.isEmpty == true)
+
+			configuration.type = .none
+			configuration.maxInputLength = 3
+			textfield.configuration = configuration
+			textfield.setText("Joe")
+			textfield.cleanText()
+			XCTAssertTrue(textfield.textField.secureText == "")
+			XCTAssertTrue(textfield.state.inputLength == 0)
+			XCTAssertTrue(textfield.state.isDirty == true)
+			XCTAssertTrue(textfield.state.isEmpty == true)
+	 }
+}

--- a/VGSCollectSDK.xcodeproj/project.pbxproj
+++ b/VGSCollectSDK.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		32F4B7F424C881FA006086F3 /* Calendar+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F4B7F324C881FA006086F3 /* Calendar+extension.swift */; };
 		4404600F256801890064BEA0 /* APIHostnameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4404600D2568017E0064BEA0 /* APIHostnameValidatorTests.swift */; };
 		44168FBF2632945D0088E515 /* VGSExpirationDateTextFieldUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44168FBE2632945D0088E515 /* VGSExpirationDateTextFieldUtilsTests.swift */; };
+		441A727D272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441A727C272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift */; };
 		441B26D225DB88C50099AA3A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CC25DB88C50099AA3A /* APIClient.swift */; };
 		441B26D325DB88C50099AA3A /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CD25DB88C50099AA3A /* HTTPMethod.swift */; };
 		441B26D425DB88C50099AA3A /* APIHostURLPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CF25DB88C50099AA3A /* APIHostURLPolicy.swift */; };
@@ -294,6 +295,7 @@
 		32F4B7F324C881FA006086F3 /* Calendar+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+extension.swift"; sourceTree = "<group>"; };
 		4404600D2568017E0064BEA0 /* APIHostnameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHostnameValidatorTests.swift; sourceTree = "<group>"; };
 		44168FBE2632945D0088E515 /* VGSExpirationDateTextFieldUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSExpirationDateTextFieldUtilsTests.swift; sourceTree = "<group>"; };
+		441A727C272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldMaxInputLengthTests.swift; sourceTree = "<group>"; };
 		441B26CC25DB88C50099AA3A /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		441B26CD25DB88C50099AA3A /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		441B26CF25DB88C50099AA3A /* APIHostURLPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIHostURLPolicy.swift; sourceTree = "<group>"; };
@@ -1092,6 +1094,7 @@
 				FDA680DE239844FC00372817 /* CardTextFieldTests.swift */,
 				324B5E7924A3A34F0036867E /* ValidationRulesTest.swift */,
 				32AFB93624FFD218007FFCAE /* VGSTextFieldTests.swift */,
+				441A727C272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift */,
 			);
 			path = "Text Fields Tests";
 			sourceTree = "<group>";
@@ -1674,6 +1677,7 @@
 				44D520AE2672218A005AB588 /* VGSFlatJSONStructMappingTests.swift in Sources */,
 				FDF696E123463ACB00063507 /* TextFielsStyleUI.swift in Sources */,
 				3213005B241FA0BE0062FEF0 /* VGSCollectTest+Validation.swift in Sources */,
+				441A727D272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift in Sources */,
 				32059CD42417EACC003E9481 /* UtilsTest.swift in Sources */,
 				32448009244606E4003A0676 /* CardHolderNameFieldTests.swift in Sources */,
 				32C894DE256D4AE400DC5648 /* UIDevice+extension.swift in Sources */,

--- a/demoapp/demoapp/UseCases/CardsDataCollectingViewController.swift
+++ b/demoapp/demoapp/UseCases/CardsDataCollectingViewController.swift
@@ -135,6 +135,7 @@ class CardsDataCollectingViewController: UIViewController {
         expDateConfiguration.type = .expDate
 				expDateConfiguration.inputDateFormat = .shortYear
         expDateConfiguration.outputDateFormat = .longYear
+				expCardDate.maxLength = 4
       
         /// Default .expDate format is "##/##"
         expDateConfiguration.formatPattern = "##/##"
@@ -162,6 +163,7 @@ class CardsDataCollectingViewController: UIViewController {
         /// Required to be not empty
       
         cardHolderName.textAlignment = .natural
+				cardHolderName.maxLength = 5
         cardHolderName.configuration = holderConfiguration
         cardHolderName.placeholder = "Cardholder Name"
         

--- a/demoapp/demoapp/UseCases/CardsDataCollectingViewController.swift
+++ b/demoapp/demoapp/UseCases/CardsDataCollectingViewController.swift
@@ -135,8 +135,7 @@ class CardsDataCollectingViewController: UIViewController {
         expDateConfiguration.type = .expDate
 				expDateConfiguration.inputDateFormat = .shortYear
         expDateConfiguration.outputDateFormat = .longYear
-				expCardDate.maxLength = 4
-      
+
         /// Default .expDate format is "##/##"
         expDateConfiguration.formatPattern = "##/##"
         
@@ -163,7 +162,8 @@ class CardsDataCollectingViewController: UIViewController {
         /// Required to be not empty
       
         cardHolderName.textAlignment = .natural
-				cardHolderName.maxLength = 5
+				// Set max input length
+				//holderConfiguration.maxInputLength = 32
         cardHolderName.configuration = holderConfiguration
         cardHolderName.placeholder = "Cardholder Name"
         


### PR DESCRIPTION

## Description of changes
- add `maxInputLength` to `VGSConfiguration`;
- add unit tests;
- log warning when both `.formatPattern` and `.maxInputLength` are in use.
