### PR TITLE
Update CardIO with enforced light mode

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/verygoodsecurity/CardIOSDK-iOS.git",
         "state": {
           "branch": null,
-          "revision": "2a764795a837f259a9f50845fbd5fbba69b330bf",
-          "version": "5.5.5"
+          "revision": "9f21bec2d2f12d14ffbe8305c44ceff9b60e35af",
+          "version": "5.5.7"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
 			.package(
 						name: "CardIOSDK",
 						url: "https://github.com/verygoodsecurity/CardIOSDK-iOS.git",
-						.exact("5.5.5")
+						.exact("5.5.7")
 			)
     ],
     targets: [

--- a/VGSCollectSDK.podspec
+++ b/VGSCollectSDK.podspec
@@ -43,6 +43,6 @@ Pod::Spec.new do |spec|
   spec.subspec 'CardIO' do |cardIO|
     cardIO.source_files  = "Sources/VGSCardIOCollector", "Sources/VGSCardIOCollector/**/*.{swift}", "Sources/VGSCardIOCollector/**/*.{h, m}"
     cardIO.dependency "VGSCollectSDK/Core"
-    cardIO.dependency "CardIOSDK", "5.5.6"
+    cardIO.dependency "CardIOSDK", "5.5.7"
   end
 end


### PR DESCRIPTION
## Fixes [iOSSDK-377]

Update to `CardIO 5.5.7` with enforced light mode.