### PR TITLE
Add prefix to httpmethod enum

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -7,6 +7,7 @@ Bin length expanded from 6 to 8 digits for [Visa](https://ht.visa.com/dam/VCOM/g
 ### Migrating from versions < v1.9.7
 #### Swift PM modules updates.
 For SDK integration with Swift Package Manager you don't need to import `VGSPaymentCards` module.
+### Migrating from versions < v1.11.3
 
 Before:
 
@@ -161,3 +162,7 @@ let expDateConfiguration = VGSConfiguration(collector: vgsCollect, fieldName: "c
 expDateConfiguration.type = .expDate
 expDateConfiguration.divider = ""
 ```
+
+### Migrating from versions < v1.11.3
+#### Rename enum 
+`HTTPMethod` -> `VGSCollectHTTPMethod`

--- a/Sources/VGSCollectSDK/Core/API/APIClient.swift
+++ b/Sources/VGSCollectSDK/Core/API/APIClient.swift
@@ -123,7 +123,7 @@ class APIClient {
 
 	// MARK: - Send request
 
-  func sendRequest(path: String, method: HTTPMethod = .post, routeId: String? = nil, value: BodyData, completion block: ((_ response: VGSResponse) -> Void)? ) {
+  func sendRequest(path: String, method: VGSCollectHTTPMethod = .post, routeId: String? = nil, value: BodyData, completion block: ((_ response: VGSResponse) -> Void)? ) {
 
     let sendRequestBlock: (URL?) -> Void = {url in
 			guard var requestURL = url else {
@@ -172,7 +172,7 @@ class APIClient {
 		}
 	}
 
-	private  func sendRequest(to url: URL, method: HTTPMethod = .post, value: BodyData, completion block: ((_ response: VGSResponse) -> Void)? ) {
+	private  func sendRequest(to url: URL, method: VGSCollectHTTPMethod = .post, value: BodyData, completion block: ((_ response: VGSResponse) -> Void)? ) {
 
 		// Add headers.
 		var headers = APIClient.defaultHttpHeaders

--- a/Sources/VGSCollectSDK/Core/API/HTTPMethod.swift
+++ b/Sources/VGSCollectSDK/Core/API/HTTPMethod.swift
@@ -18,7 +18,7 @@ public typealias HTTPHeaders = [String: String]
 internal typealias BodyData = [String: Any]
 
 /// HTTP request methods
-public enum HTTPMethod: String {
+public enum VGSCollectHTTPMethod: String {
 		/// GET method.
 		case get     = "GET"
 		/// POST method.

--- a/Sources/VGSCollectSDK/Core/API/VGSCollectHTTPMethod.swift
+++ b/Sources/VGSCollectSDK/Core/API/VGSCollectHTTPMethod.swift
@@ -1,5 +1,5 @@
 //
-//  HTTPMethod.swift
+//  VGSCollectHTTPMethod.swift
 //  VGSCollectSDK
 //
 //  Created on 16.02.2021.

--- a/Sources/VGSCollectSDK/Core/Analytics/VGSAnalyticsClient.swift
+++ b/Sources/VGSCollectSDK/Core/Analytics/VGSAnalyticsClient.swift
@@ -120,7 +120,7 @@ public class VGSAnalyticsClient {
 internal extension VGSAnalyticsClient {
   
   // send events
-  func sendAnalyticsRequest(method: HTTPMethod = .post, path: String = "vgs", data: [String: Any] ) {
+  func sendAnalyticsRequest(method: VGSCollectHTTPMethod = .post, path: String = "vgs", data: [String: Any] ) {
     
       // Check if tracking events enabled
       guard shouldCollectAnalytics else {

--- a/Sources/VGSCollectSDK/Core/Collector/VGSCollect+network.swift
+++ b/Sources/VGSCollectSDK/Core/Collector/VGSCollect+network.swift
@@ -15,7 +15,7 @@ extension VGSCollect {
      
      - Parameters:
         - path: Inbound rout path for your organization vault.
-        - method: HTTPMethod, default is `.post`.
+        - method: VGSCollectHTTPMethod, default is `.post`.
         - routeId: id of VGS Proxy Route, default is `nil`.
         - extraData: Any data you want to send together with data from VGSTextFields , default is `nil`.
 	      - requestOptions: `VGSCollectRequestOptions` object, holds additional request options. Default options are `.nestedJSON`.
@@ -24,7 +24,7 @@ extension VGSCollect {
      - Note:
         Errors can be returned in the `NSURLErrorDomain` and `VGSCollectSDKErrorDomain`.
     */
-  public func sendData(path: String, method: HTTPMethod = .post, routeId: String? = nil, extraData: [String: Any]? = nil, requestOptions: VGSCollectRequestOptions = VGSCollectRequestOptions(), completion block: @escaping (VGSResponse) -> Void) {
+  public func sendData(path: String, method: VGSCollectHTTPMethod = .post, routeId: String? = nil, extraData: [String: Any]? = nil, requestOptions: VGSCollectRequestOptions = VGSCollectRequestOptions(), completion block: @escaping (VGSResponse) -> Void) {
       
         // Content analytics.
         var content: [String] = ["textField"]
@@ -80,7 +80,7 @@ extension VGSCollect {
      - Note:
         Errors can be returned in the `NSURLErrorDomain` and `VGSCollectSDKErrorDomain`.
     */
-    public func sendFile(path: String, method: HTTPMethod = .post, routeId: String? = nil, extraData: [String: Any]? = nil, completion block: @escaping (VGSResponse) -> Void) {
+    public func sendFile(path: String, method: VGSCollectHTTPMethod = .post, routeId: String? = nil, extraData: [String: Any]? = nil, completion block: @escaping (VGSResponse) -> Void) {
 
         var content: [String] = ["file"]
         if !(extraData?.isEmpty ?? true) {
@@ -181,7 +181,7 @@ extension VGSCollect {
   public func tokenizeData(routeId: String? = nil, completion block: @escaping (VGSTokenizationResponse) -> Void) {
     // Default request params
     let path = "tokens"
-    let method = HTTPMethod.post
+    let method = VGSCollectHTTPMethod.post
     
     // Check fields validation status
     if let error = validateStoredInputData() {

--- a/Sources/VGSCollectSDK/Utils/Extensions/Utils.swift
+++ b/Sources/VGSCollectSDK/Utils/Extensions/Utils.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+@testable import VGSCollectSDK
 
 /// Merge two  <key:value> objects and their nested values. Returns [String: Any]. Values in d2 will override values in d1 if keys are same!!!!
 func deepMerge(_ d1: [String: Any], _ d2: [String: Any]) -> [String: Any] {

--- a/VGSCollectSDK.xcodeproj/project.pbxproj
+++ b/VGSCollectSDK.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		035179A72859BCC400394BFC /* VGSCardHolderNameTokenizationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035179A62859BCC400394BFC /* VGSCardHolderNameTokenizationConfiguration.swift */; };
 		035179A92859BD5500394BFC /* VGSTokenizationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035179A82859BD5500394BFC /* VGSTokenizationConfiguration.swift */; };
 		038EDA0D286F2EFF00AF3CF2 /* TokenizationApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038EDA0C286F2EFF00AF3CF2 /* TokenizationApiTests.swift */; };
-		03DDAAF928632DF800337BA8 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CD25DB88C50099AA3A /* HTTPMethod.swift */; };
 		32059CD02417E02E003E9481 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32059CCF2417E02E003E9481 /* Utils.swift */; };
 		32059CD12417E02E003E9481 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32059CCF2417E02E003E9481 /* Utils.swift */; };
 		32059CD42417EACC003E9481 /* UtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32059CD22417EACC003E9481 /* UtilsTest.swift */; };
@@ -95,13 +94,14 @@
 		44168FBF2632945D0088E515 /* VGSExpirationDateTextFieldUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44168FBE2632945D0088E515 /* VGSExpirationDateTextFieldUtilsTests.swift */; };
 		441A727D272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441A727C272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift */; };
 		441B26D225DB88C50099AA3A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CC25DB88C50099AA3A /* APIClient.swift */; };
-		441B26D325DB88C50099AA3A /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CD25DB88C50099AA3A /* HTTPMethod.swift */; };
 		441B26D425DB88C50099AA3A /* APIHostURLPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26CF25DB88C50099AA3A /* APIHostURLPolicy.swift */; };
 		441B26D525DB88C50099AA3A /* APIHostnameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26D025DB88C50099AA3A /* APIHostnameValidator.swift */; };
 		441B26D625DB88C50099AA3A /* APICustomHostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26D125DB88C50099AA3A /* APICustomHostStatus.swift */; };
 		441B26DD25DB88DB0099AA3A /* VGSResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26DC25DB88DB0099AA3A /* VGSResponse.swift */; };
 		441B26E925DB8D950099AA3A /* APIClient+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26E825DB8D950099AA3A /* APIClient+Utils.swift */; };
 		441B26F025DB956B0099AA3A /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B26EF25DB956B0099AA3A /* URL+Extensions.swift */; };
+		441B4E9B293EFD050011EFAC /* VGSCollectHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B4E9A293EFD050011EFAC /* VGSCollectHTTPMethod.swift */; };
+		441B4E9D293EFD2B0011EFAC /* VGSCollectHTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441B4E9C293EFD2B0011EFAC /* VGSCollectHTTPMethod.swift */; };
 		442A39132909718F007CCC58 /* VGSTokenizationTestJSON_DefaultConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 442A39122909718F007CCC58 /* VGSTokenizationTestJSON_DefaultConfig.json */; };
 		442A391729097425007CCC58 /* VGSTokenizationResponseMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442A391629097425007CCC58 /* VGSTokenizationResponseMappingTests.swift */; };
 		442BB2C6287314DC001FD26B /* MockedData.plist in Resources */ = {isa = PBXBuildFile; fileRef = 442BB2C5287314DC001FD26B /* MockedData.plist */; };
@@ -291,13 +291,14 @@
 		44168FBE2632945D0088E515 /* VGSExpirationDateTextFieldUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSExpirationDateTextFieldUtilsTests.swift; sourceTree = "<group>"; };
 		441A727C272AAEEA0036BECB /* TextFieldMaxInputLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldMaxInputLengthTests.swift; sourceTree = "<group>"; };
 		441B26CC25DB88C50099AA3A /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		441B26CD25DB88C50099AA3A /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		441B26CF25DB88C50099AA3A /* APIHostURLPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIHostURLPolicy.swift; sourceTree = "<group>"; };
 		441B26D025DB88C50099AA3A /* APIHostnameValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIHostnameValidator.swift; sourceTree = "<group>"; };
 		441B26D125DB88C50099AA3A /* APICustomHostStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APICustomHostStatus.swift; sourceTree = "<group>"; };
 		441B26DC25DB88DB0099AA3A /* VGSResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSResponse.swift; sourceTree = "<group>"; };
 		441B26E825DB8D950099AA3A /* APIClient+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Utils.swift"; sourceTree = "<group>"; };
 		441B26EF25DB956B0099AA3A /* URL+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
+		441B4E9A293EFD050011EFAC /* VGSCollectHTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VGSCollectHTTPMethod.swift; path = Sources/VGSCollectSDK/Core/API/VGSCollectHTTPMethod.swift; sourceTree = SOURCE_ROOT; };
+		441B4E9C293EFD2B0011EFAC /* VGSCollectHTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VGSCollectHTTPMethod.swift; path = Sources/VGSCollectSDK/Core/API/VGSCollectHTTPMethod.swift; sourceTree = SOURCE_ROOT; };
 		442A39122909718F007CCC58 /* VGSTokenizationTestJSON_DefaultConfig.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VGSTokenizationTestJSON_DefaultConfig.json; sourceTree = "<group>"; };
 		442A391629097425007CCC58 /* VGSTokenizationResponseMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VGSTokenizationResponseMappingTests.swift; sourceTree = "<group>"; };
 		442BB2C5287314DC001FD26B /* MockedData.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = MockedData.plist; sourceTree = "<group>"; };
@@ -677,7 +678,6 @@
 				441B26CC25DB88C50099AA3A /* APIClient.swift */,
 				44F8F51A25DBD1860052647A /* SatelliteUtils */,
 				441B26CE25DB88C50099AA3A /* APIHostName */,
-				441B26CD25DB88C50099AA3A /* HTTPMethod.swift */,
 				441B26DC25DB88DB0099AA3A /* VGSResponse.swift */,
 				441B26E825DB8D950099AA3A /* APIClient+Utils.swift */,
 			);
@@ -687,6 +687,8 @@
 		441B26CE25DB88C50099AA3A /* APIHostName */ = {
 			isa = PBXGroup;
 			children = (
+				441B4E9A293EFD050011EFAC /* VGSCollectHTTPMethod.swift */,
+				441B4E9C293EFD2B0011EFAC /* VGSCollectHTTPMethod.swift */,
 				441B26CF25DB88C50099AA3A /* APIHostURLPolicy.swift */,
 				441B26D025DB88C50099AA3A /* APIHostnameValidator.swift */,
 				441B26D125DB88C50099AA3A /* APICustomHostStatus.swift */,
@@ -1548,10 +1550,11 @@
 				441B26DD25DB88DB0099AA3A /* VGSResponse.swift in Sources */,
 				325AB9CB2420C5410024134B /* VGSFilePickerControllerDelegate.swift in Sources */,
 				328B5C7023C8DA2600A39515 /* String+extension.swift in Sources */,
-				441B26D325DB88C50099AA3A /* HTTPMethod.swift in Sources */,
 				32093D7D25CD9F88006CD242 /* VGSCollectLogEvent.swift in Sources */,
 				44ECD60427D9C18C00460FDF /* CheckSumAlgoritmType.swift in Sources */,
 				3215C4BC260DAF3D00F21259 /* VGSFormatSerializerProtocol.swift in Sources */,
+				441B4E9B293EFD050011EFAC /* VGSCollectHTTPMethod.swift in Sources */,
+				441B4E9D293EFD2B0011EFAC /* VGSCollectHTTPMethod.swift in Sources */,
 				32093D8625CDA3E6006CD242 /* VGSReadWriteSafeContainer.swift in Sources */,
 				FD3C01C323AFC0980096B4A4 /* VGSTextField+CVC.swift in Sources */,
 				44F8F51C25DBD1950052647A /* VGSCollectSatelliteUtils.swift in Sources */,
@@ -1639,7 +1642,6 @@
 				FDE247CD2467439D008D75B0 /* ApiClientTests.swift in Sources */,
 				44A67DDB25DCE3D100906957 /* VGSAPIClientSatelliteTests.swift in Sources */,
 				FDA680DF239844FC00372817 /* CardTextFieldTests.swift in Sources */,
-				03DDAAF928632DF800337BA8 /* HTTPMethod.swift in Sources */,
 				44447F8025F7651100D4CE68 /* JSONData+Extensions.swift in Sources */,
 				32F23A7924B752E200E389F7 /* PaymentCardsTest.swift in Sources */,
 				FDAAB6AD249A9257001F5C1A /* FileInfoTest.swift in Sources */,


### PR DESCRIPTION
## Fixes [CSDK-363]

## Description of changes
- add prefix to 'HTTPMethod' to avoid name clashing
- update migration guide

[CSDK-363]: https://verygoodsecurity.atlassian.net/browse/CSDK-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ